### PR TITLE
[feat] 공통 응답 및 예외처리 기반 코드 추가 close #2

### DIFF
--- a/src/main/java/umc/snack/common/exception/CustomException.java
+++ b/src/main/java/umc/snack/common/exception/CustomException.java
@@ -1,0 +1,14 @@
+package umc.snack.common.exception;
+
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+
+    public CustomException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/umc/snack/common/exception/ErrorCode.java
+++ b/src/main/java/umc/snack/common/exception/ErrorCode.java
@@ -1,0 +1,37 @@
+package umc.snack.common.exception;
+
+public enum ErrorCode {
+
+    // 인증/Auth
+    AUTH_2001(401, "인증 정보가 누락되었습니다."),
+    AUTH_2002(401, "유효하지 않은 토큰입니다."),
+    AUTH_2003(419, "토큰이 만료되었습니다."),
+    AUTH_2004(403, "접근 권한이 없습니다."),
+    USER_2001(400, "가입되지 않은 계정입니다."),
+    USER_2002(401, "로그인 실패"),
+
+    // 요청/파라미터
+    REQ_3001(400, "필수 파라미터가 누락되었습니다."),
+    REQ_3002(400, "파라미터 형식이 잘못되었습니다."),
+    REQ_3003(415, "지원하지 않는 Content-Type입니다."),
+
+    // API
+    API_4001(404, "존재하지 않는 API입니다."),
+    API_4002(405, "지원하지 않는 HTTP 메서드입니다."),
+
+    // 서버
+    SERVER_5001(500, "서버 내부 오류입니다."),
+    SERVER_5002(504, "외부 서비스 응답 지연"),
+    SERVER_5003(503, "서버가 일시적으로 불안정합니다.");
+
+    private final int status;
+    private final String message;
+
+    ErrorCode(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+
+    public int getStatus() { return status; }
+    public String getMessage() { return message; }
+}

--- a/src/main/java/umc/snack/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/umc/snack/common/exception/GlobalExceptionHandler.java
@@ -1,4 +1,26 @@
 package umc.snack.common.exception;
 
-public class BlobalExceptionHandler {
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import umc.snack.common.response.ApiResponse;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<ApiResponse<Object>> handleCustomException(CustomException ex) {
+        ErrorCode code = ex.getErrorCode();
+        return ResponseEntity
+                .status(code.getStatus())
+                .body(ApiResponse.fail(code.name(), code.getMessage(), null));
+    }
+
+    // 그 외 Exception 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Object>> handleException(Exception ex) {
+        return ResponseEntity
+                .status(500)
+                .body(ApiResponse.fail("SERVER_5001", "서버 내부 오류입니다.", ex.getMessage()));
+    }
 }

--- a/src/main/java/umc/snack/common/response/ApiResponse.java
+++ b/src/main/java/umc/snack/common/response/ApiResponse.java
@@ -1,0 +1,28 @@
+package umc.snack.common.response;
+
+import lombok.Getter;
+
+@Getter
+public class ApiResponse<T> {
+    private boolean isSuccess;
+    private String code;
+    private String message;
+    private T result;
+    private Object error;
+
+    public ApiResponse(boolean isSuccess, String code, String message, T result, Object error) {
+        this.isSuccess = isSuccess;
+        this.code = code;
+        this.message = message;
+        this.result = result;
+        this.error = error;
+    }
+
+    public static <T> ApiResponse<T> success(String code, String message, T result) {
+        return new ApiResponse<>(true, code, message, result, null);
+    }
+
+    public static <T> ApiResponse<T> fail(String code, String message, Object errorDetail) {
+        return new ApiResponse<>(false, code, message, null, errorDetail);
+    }
+}


### PR DESCRIPTION
## 작업 내용
- 공통 응답 포맷 (`ApiResponse`) 정의
- 공통 예외 처리 기반 구조 (`ErrorCode`, `CustomException`, `GlobalExceptionHandler`) 구성
- 팀 전체 공통 포맷 통일을 위한 기반 코드 설정

## 변경 사항
- `common/response/ApiResponse.java` 추가
- `common/exception/ErrorCode.java`, `CustomException.java`, `GlobalExceptionHandler.java` 추가

## 테스트 방법
- Postman으로 테스트 (ExampleController 만들어서 테스트 진행, 커밋 반영 안 함)

## 관련 이슈
- close #2 

## 특이사항


---

## 머지 전 필수 체크리스트
- [x] 제목 형식 지켰음 (`[기능] ~`)
- [x] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] 마일스톤 지정 완료
- [x] Assignee 지정 완료
- [ ] Reviewer 지정 완료
- [x] GitHub Actions 테스트 통과 확인

> ⚠ 단독 작업이므로 체크리스트 일부 미충족 상태에서 직접 머지합니다
