### PR TITLE
[chore] SecurityConfig 파일에 api 경로 추가 close #22

### DIFF
--- a/src/main/java/umc/snack/common/config/SecurityConfig.java
+++ b/src/main/java/umc/snack/common/config/SecurityConfig.java
@@ -17,8 +17,21 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/swagger-resources/**",
                                 "/swagger-ui.html",
-                                "/webjars/**"
+                                "/webjars/**",
+                                // 전체 공개 api
+                                "/api/users/signup",
+                                "/api/auth/login",
+                                "/api/auth/kakao",
+                                "/auth/kakao/callback",
+                                "/api/articles/**/related-articles",
+                                "/api/articles/search",
+                                "/api/articles/main",
+                                // 관리자 공개 api -> 개발 단계에서는 전체 공개
+                                "/api/articles/crawl/status",
+                                "/api/articles/**/summarize",
+                                "/api/terms"
                         ).permitAll()
+                        // 나머지는 모두 JWT 토큰 인증 필요
                         .anyRequest().authenticated()
                 )
                 .csrf(csrf -> csrf.disable());


### PR DESCRIPTION

## 작업 내용
- SecurityConfig에 api 접근 권한 설정

## 변경 사항
- 전체 공개 api 추가
- 관리자 공개 api 추가
https://www.notion.so/SwaggerConfig-SecurityConfig-22b89e29bd9f80cfb452cb6c33a1cd65
여기에 상세 내용 작성했습니다.

## 테스트 방법
- Swagger 잘 실행됨

## 관련 이슈
- close #22

## 특이사항
- 나중에 배포할 때 권한 바꿔야 합니다.

---

## 머지 전 필수 체크리스트
- [x] 제목 형식 지켰음 (`[기능] ~`)
- [x] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] 마일스톤 지정 완료
- [x] Assignee 지정 완료
- [x] Reviewer 지정 완료
- [ ] GitHub Actions 테스트 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**
