### PR TITLE
[feat] Quiz Controller, Memo Controller 생성

### DIFF
--- a/src/main/java/umc/snack/controller/memo/MemoController.java
+++ b/src/main/java/umc/snack/controller/memo/MemoController.java
@@ -1,0 +1,40 @@
+package umc.snack.controller.memo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/articles/{article_id}/memos")
+@RequiredArgsConstructor
+@Tag(name = "Memo", description = "기사 메모 관련 API")
+public class MemoController {
+    @Operation(summary = "특정 기사에 메모 작성", description = "현재 보고 있는 기사에 대한 메모를 작성하는 API입니다.")
+    @PostMapping
+    public ResponseEntity<?> createMemo(
+            @PathVariable Long article_id,
+            @RequestBody Object NoteDto) {
+        // TODO: 개발 예정
+        return ResponseEntity.ok("메모 작성 API - 개발 예정 (articleId: " + article_id + ")");
+    }
+
+    @Operation(summary = "특정 기사의 메모 수정", description = "특정 기사에 작성된 메모를 수정하는 API입니다.")
+    @PatchMapping("/{memo_id}")
+    public ResponseEntity<?> updateMemo(
+            @PathVariable Long article_id,
+            @PathVariable Long memo_id,
+            @RequestBody Object NoteDto) {
+        // TODO: 개발 예정
+        return ResponseEntity.ok("메모 수정 API - 개발 예정 (articleId: " + article_id + ", memoId: " + memo_id + ")");
+    }
+
+    @Operation(summary = "특정 기사의 메모 삭제", description = "특정 기사에 작성된 메모를 삭제하는 API입니다.")
+    @DeleteMapping("/{memo_id}")
+    public ResponseEntity<?> deleteMemo(
+            @PathVariable Long article_id,
+            @PathVariable Long memo_id) {
+        // TODO: 개발 예정
+        return ResponseEntity.ok("메모 삭제 API - 개발 예정 (articleId: " + article_id + ", memoId: " + memo_id + ")");
+    }
+}

--- a/src/main/java/umc/snack/controller/quiz/QuizController.java
+++ b/src/main/java/umc/snack/controller/quiz/QuizController.java
@@ -1,0 +1,34 @@
+package umc.snack.controller.quiz;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import umc.snack.domain.quiz.dto.QuizSubmissionRequestDto;
+
+@RestController
+@RequestMapping("/api")
+@Tag(name = "Quiz", description = "퀴즈 관련 API")
+public class QuizController {
+
+    @Operation(summary = "기사에 해당하는 퀴즈 조회", description = "특정 기사에 해당하는 퀴즈 4개를 반환하는 API입니다.")
+    @GetMapping("/articles/{article_id}/quiz")
+    public ResponseEntity<?> getQuiz(
+            @PathVariable("article_id") Long articleId) {
+
+        // TODO: 개발 예정
+        return ResponseEntity.ok("기사 퀴즈 조회 API - 개발 예정 (articleId: " + articleId + ")");
+    }
+
+    @Operation(summary = "퀴즈 제출", description = "퀴즈를 푼 뒤 정답 및 점수를 반환받는 API입니다.")
+    @PostMapping("/quizzes/submit")
+    public ResponseEntity<?> submitQuiz(
+            @PathVariable Long quiz_id,
+            @RequestBody QuizSubmissionRequestDto requestDto,
+            @RequestBody Object submitDto) {
+        // TODO: 개발 예정
+        return ResponseEntity.ok("퀴즈 제출 API - 개발 예정 (quizId: " + quiz_id + ")");
+    }
+}

--- a/src/main/java/umc/snack/domain/quiz/dto/AnswerDto.java
+++ b/src/main/java/umc/snack/domain/quiz/dto/AnswerDto.java
@@ -1,0 +1,6 @@
+package umc.snack.domain.quiz.dto;
+
+public class AnswerDto {
+    private Long quizId;
+    private int userAnswer;
+}

--- a/src/main/java/umc/snack/domain/quiz/dto/QuizSubmissionRequestDto.java
+++ b/src/main/java/umc/snack/domain/quiz/dto/QuizSubmissionRequestDto.java
@@ -1,0 +1,7 @@
+package umc.snack.domain.quiz.dto;
+
+import java.util.List;
+
+public class QuizSubmissionRequestDto {
+    private List<AnswerDto> answers;
+}

--- a/src/main/java/umc/snack/domain/quiz/dto/UserQuizSubmissionDto.java
+++ b/src/main/java/umc/snack/domain/quiz/dto/UserQuizSubmissionDto.java
@@ -5,7 +5,7 @@ import lombok.*;
 @Getter
 @AllArgsConstructor
 @Builder
-public class UserQuizResultDto {
+public class UserQuizSubmissionDto {
     private Long resultId;
     private Long userId;
     private Long quizId;


### PR DESCRIPTION
## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- Quiz Controller
- Memo Controller 생성
- Quiz DTO 수정

## 변경 사항
- QuizController
- MemoController
- AnswerDto
- QuizSubmissionRequestDto

## 테스트 방법
- Swagger로 테스트
<img width="3164" height="1938" alt="image" src="https://github.com/user-attachments/assets/e3170f0a-04ef-46d9-9f73-788b9233323a" />

## 관련 이슈
- close #37

## 특이사항
- 리뷰 시 반드시 봐야 하는 부분이 있다면

---

## 머지 전 필수 체크리스트
- [x] 제목 형식 지켰음 (`[기능] ~`)
- [x] 라벨 지정 완료 (e.g. feature, bugfix)
- [x] Assignee 지정 완료
- [x] Reviewer 지정 완료

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**
