### PR TITLE
[fix] 크롤링 중복 필터 추가

### DIFF
--- a/src/main/java/umc/snack/crawler/service/ArticleCollectorService.java
+++ b/src/main/java/umc/snack/crawler/service/ArticleCollectorService.java
@@ -111,9 +111,14 @@ public class ArticleCollectorService {
             // 본문이 없거나 너무 짧은 경우 제외
             if (text == null || text.length() < 50) return false;
 
-            // 한글 비율 계산
+            // 한글 비율 계산 (완성형 한글 + 자모음 포함)
             long totalLength = text.length();
-            long koreanCharCount = text.chars().filter(c -> (c >= 0xAC00 && c <= 0xD7A3)).count();
+            long koreanCharCount = text.chars()
+                    .filter(c -> (c >= 0xAC00 && c <= 0xD7A3) || // 완성형 한글
+                            (c >= 0x1100 && c <= 0x11FF) || // 자음
+                            (c >= 0x3130 && c <= 0x318F) || // 호환 자모
+                            (c >= 0xA960 && c <= 0xA97F))   // 확장 자모
+                    .count();
             double ratio = (double) koreanCharCount / totalLength;
 
             // 한글 비율이 60% 이상일 때만 유효하다고 판단

--- a/src/main/java/umc/snack/crawler/service/ArticleCollectorService.java
+++ b/src/main/java/umc/snack/crawler/service/ArticleCollectorService.java
@@ -3,12 +3,14 @@ package umc.snack.crawler.service;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
 import org.springframework.stereotype.Service;
+import umc.snack.repository.article.CrawledArticleRepository;
 
 import java.io.IOException;
 import java.net.URI;
@@ -16,14 +18,15 @@ import java.net.URISyntaxException;
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
-import java.util.Collections;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 @Slf4j
 @Service
+@RequiredArgsConstructor
 public class ArticleCollectorService {
+
+    private final CrawledArticleRepository crawledArticleRepository;
 
     // 주요 언론사 OID 목록 (한겨레 포함 8개)
     private static final List<String> NEWS_OIDS = List.of("028", "025", "023", "020", "032", "469", "022", "081");
@@ -35,24 +38,30 @@ public class ArticleCollectorService {
 
     public List<String> collectRandomArticleLinks() {
         Set<String> validLinks = new HashSet<>();
+        Set<String> alreadyCrawledLinks = crawledArticleRepository.findAllArticleUrls(); // ✅ 기존 수집된 기사 링크
+
         DateTimeFormatter dateFormatter = DateTimeFormatter.BASIC_ISO_DATE;
         String formattedDate = LocalDate.now().format(dateFormatter);
-        // 셔플된 언론사+섹션 조합에서 중복 없이 5개 조합만 처리
+
+        // 섞인 언론사-섹션 조합 리스트
         List<String[]> combos = new ArrayList<>();
         for (String oid : NEWS_OIDS) {
             for (String sid1 : SECTION_CODES) {
                 combos.add(new String[]{oid, sid1});
             }
         }
+
         Collections.shuffle(combos);
         for (String[] combo : combos) {
             if (validLinks.size() >= 5) break;
+
             String oid = combo[0];
             String sid1 = combo[1];
             String listUrl = String.format(
                     "https://news.naver.com/main/list.naver?mode=LSD&mid=sec&sid1=%s&oid=%s&date=%s",
                     sid1, oid, formattedDate
             );
+
             try {
                 Document doc = Jsoup.connect(listUrl)
                         .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
@@ -61,16 +70,23 @@ public class ArticleCollectorService {
 
                 Elements articleLinks = doc.select("a[href*='/article/']");
                 log.info("🔍 [{}] 링크 개수: {}", listUrl, articleLinks.size());
+
                 for (Element link : articleLinks) {
                     String href = link.attr("href");
                     String articleUrl = href.startsWith("http") ? href : NAVER_PREFIX + href;
+
+                    // 중복 필터링
+                    if (alreadyCrawledLinks.contains(articleUrl)) continue;
+
                     String extractedOid = extractOidFromUrl(articleUrl);
                     if (extractedOid == null || !NEWS_OIDS.contains(extractedOid)) continue;
+
                     if (isValidArticle(articleUrl)) {
                         validLinks.add(articleUrl);
-                        break;
+                        break; // 조합당 하나만
                     }
                 }
+
             } catch (IOException e) {
                 log.warn("[수집 실패] URL: {}, 오류: {}", listUrl, e.getMessage());
             }
@@ -80,27 +96,36 @@ public class ArticleCollectorService {
         return new ArrayList<>(validLinks);
     }
 
-    // 기사 본문이 50자가 남는지 유효성 검사
+    // 기사 본문이 50자 이상이면 유효한 기사로 판단
     private boolean isValidArticle(String url) {
         try {
             Document doc = Jsoup.connect(url)
                     .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36")
                     .timeout(3000)
                     .get();
+
             String text = doc.select("#dic_area").text();
-            if (text.isEmpty()) {
-                text = doc.select("#newsEndContents").text();
-            }
-            if (text.isEmpty()) {
-                text = doc.select("article").text();
-            }
-            return text != null && text.length() > 50; // 50자 이상이면 유효한 기사로 판단
+            if (text.isEmpty()) text = doc.select("#newsEndContents").text();
+            if (text.isEmpty()) text = doc.select("article").text();
+
+            // 본문이 없거나 너무 짧은 경우 제외
+            if (text == null || text.length() < 50) return false;
+
+            // 한글 비율 계산
+            long totalLength = text.length();
+            long koreanCharCount = text.chars().filter(c -> (c >= 0xAC00 && c <= 0xD7A3)).count();
+            double ratio = (double) koreanCharCount / totalLength;
+
+            // 한글 비율이 60% 이상일 때만 유효하다고 판단
+            return ratio >= 0.6;
+
         } catch (IOException e) {
             log.debug("기사 유효성 검사 실패: {}", url);
             return false;
         }
     }
 
+    // 수집한 링크 리스트를 JSON 문자열로 변환
     public String toJson(List<String> links) {
         try {
             ObjectMapper mapper = new ObjectMapper();
@@ -121,6 +146,7 @@ public class ArticleCollectorService {
         }
     }
 
+    // URL에서 OID 추출 (ex: /article/028/123456 → 028)
     private String extractOidFromUrl(String url) {
         try {
             String path = new URI(url).getPath();

--- a/src/main/java/umc/snack/repository/article/CrawledArticleRepository.java
+++ b/src/main/java/umc/snack/repository/article/CrawledArticleRepository.java
@@ -1,7 +1,10 @@
 package umc.snack.repository.article;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import umc.snack.domain.article.entity.CrawledArticle;
+
+import java.util.Set;
 
 public interface CrawledArticleRepository extends JpaRepository<CrawledArticle, Long> {
 
@@ -9,6 +12,6 @@ public interface CrawledArticleRepository extends JpaRepository<CrawledArticle, 
 
     long countByStatus(CrawledArticle.Status status); // 상태별 개수 세기용 (PROCESSED, FAILED 등)
 
-
-
+    @Query("SELECT c.articleUrl FROM CrawledArticle c") // 이미 크롤링한 URL을 모두 Set으로 가져오는 쿼리
+    Set<String> findAllArticleUrls();
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,10 @@
 spring:
+  jackson:
+    time-zone: Asia/Seoul
   config:
     import: optional:file:.env[.properties]
   datasource:
-    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=UTC&characterEncoding=UTF-8
+    url: jdbc:mysql://${DB_HOST}:${DB_PORT}/${DB_NAME}?useSSL=false&serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${DB_USER}
     password: ${DB_PASSWORD}
 


### PR DESCRIPTION
## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- 크롤링시 이미 크롤링한 기사 크롤링 하지 못하도록 필터링
- 한국어 기사만 크롤링하도록 필터링

## 변경 사항
- ArticleCollectorService.java
- CrawledArticleRepository.java

## 테스트 방법
- Postman, Swagger 등으로 어떻게 테스트했는지

## 관련 이슈
- close #46 

## 특이사항
- 리뷰 시 반드시 봐야 하는 부분이 있다면

---

## 머지 전 필수 체크리스트
- [x] 제목 형식 지켰음 (`[기능] ~`)
- [x] 라벨 지정 완료 (e.g. feature, bugfix)
- [x] 마일스톤 지정 완료
- [x] Assignee 지정 완료
- [x] Reviewer 지정 완료
- [ ] GitHub Actions 테스트 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 이미 수집된 기사 URL을 제외하고 새로운 기사 링크를 최대 5개까지 수집하는 기능이 추가되었습니다.
  * 기사 유효성 검사 시, 최소 50자 이상이면서 한글 비율이 60% 이상인 경우만 유효 기사로 인정됩니다.
  * 수집된 모든 기사 URL을 조회하는 기능이 추가되었습니다.
  * 애플리케이션과 데이터베이스의 시간대 설정이 Asia/Seoul로 변경되었습니다.

* **버그 수정**
  * 중복 기사 수집이 방지되어 동일한 기사가 여러 번 수집되지 않습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->