### PR TITLE
[feat] 퀴즈 조회

### DIFF
--- a/src/main/java/umc/snack/controller/quiz/QuizController.java
+++ b/src/main/java/umc/snack/controller/quiz/QuizController.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import umc.snack.common.dto.ApiResponse;
-import umc.snack.common.exception.ErrorCode;
 import umc.snack.domain.quiz.dto.QuizResponseDto;
 import umc.snack.domain.quiz.dto.QuizSubmissionRequestDto;
 import umc.snack.service.quiz.QuizService;

--- a/src/main/java/umc/snack/controller/quiz/QuizController.java
+++ b/src/main/java/umc/snack/controller/quiz/QuizController.java
@@ -6,20 +6,33 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import umc.snack.common.dto.ApiResponse;
+import umc.snack.common.exception.ErrorCode;
+import umc.snack.domain.quiz.dto.QuizResponseDto;
 import umc.snack.domain.quiz.dto.QuizSubmissionRequestDto;
+import umc.snack.service.quiz.QuizService;
 
 @RestController
 @RequestMapping("/api")
+@RequiredArgsConstructor
 @Tag(name = "Quiz", description = "퀴즈 관련 API")
 public class QuizController {
 
+    private final QuizService quizService;
+
     @Operation(summary = "기사에 해당하는 퀴즈 조회", description = "특정 기사에 해당하는 퀴즈 4개를 반환하는 API입니다.")
     @GetMapping("/articles/{article_id}/quiz")
-    public ResponseEntity<?> getQuiz(
-            @PathVariable("article_id") Long articleId) {
+    public ResponseEntity<ApiResponse<QuizResponseDto>> getQuiz(@PathVariable("article_id") Long articleId) {
 
-        // TODO: 개발 예정
-        return ResponseEntity.ok("기사 퀴즈 조회 API - 개발 예정 (articleId: " + articleId + ")");
+        QuizResponseDto quizResponse = quizService.getQuizzesByArticleId(articleId);
+
+        ApiResponse<QuizResponseDto> response = ApiResponse.onSuccess(
+                "QUIZ_7500",
+                "기사 퀴즈 조회에 성공하였습니다.",
+                quizResponse
+        );
+
+        return ResponseEntity.ok(response);
     }
 
     @Operation(summary = "퀴즈 제출", description = "퀴즈를 푼 뒤 정답 및 점수를 반환받는 API입니다.")

--- a/src/main/java/umc/snack/domain/quiz/dto/QuizResponseDto.java
+++ b/src/main/java/umc/snack/domain/quiz/dto/QuizResponseDto.java
@@ -1,0 +1,23 @@
+package umc.snack.domain.quiz.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@Builder
+public class QuizResponseDto {
+    private List<QuizContentDto> quizContent;
+    
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class QuizContentDto {
+        private Long quizId;
+        private String question;
+        private List<String> options;
+    }
+} 

--- a/src/main/java/umc/snack/repository/quiz/ArticleQuizRepository.java
+++ b/src/main/java/umc/snack/repository/quiz/ArticleQuizRepository.java
@@ -1,0 +1,17 @@
+package umc.snack.repository.quiz;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+import umc.snack.domain.quiz.ArticleQuizId;
+import umc.snack.domain.quiz.entity.ArticleQuiz;
+
+import java.util.List;
+
+@Repository
+public interface ArticleQuizRepository extends JpaRepository<ArticleQuiz, ArticleQuizId> {
+    
+    @Query("SELECT aq FROM ArticleQuiz aq JOIN FETCH aq.quiz WHERE aq.articleId = :articleId")
+    List<ArticleQuiz> findByArticleIdWithQuiz(@Param("articleId") Long articleId);
+} 

--- a/src/main/java/umc/snack/repository/quiz/QuizRepository.java
+++ b/src/main/java/umc/snack/repository/quiz/QuizRepository.java
@@ -1,0 +1,9 @@
+package umc.snack.repository.quiz;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import umc.snack.domain.quiz.entity.Quiz;
+
+@Repository
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+} 

--- a/src/main/java/umc/snack/service/quiz/QuizService.java
+++ b/src/main/java/umc/snack/service/quiz/QuizService.java
@@ -1,0 +1,79 @@
+package umc.snack.service.quiz;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.snack.common.exception.CustomException;
+import umc.snack.common.exception.ErrorCode;
+import umc.snack.domain.quiz.dto.QuizResponseDto;
+import umc.snack.domain.quiz.entity.ArticleQuiz;
+import umc.snack.domain.quiz.entity.Quiz;
+import umc.snack.repository.article.ArticleRepository;
+import umc.snack.repository.quiz.ArticleQuizRepository;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class QuizService {
+    
+    // 기사 데이터를 데이터베이스에서 조회하거나 저장
+    private final ArticleRepository articleRepository;
+    // 기사와 퀴즈 연결정보
+    private final ArticleQuizRepository articleQuizRepository;
+    // JSON 문자열을 Map으로 파싱하는 객체
+    private final ObjectMapper objectMapper;
+    
+    public QuizResponseDto getQuizzesByArticleId(Long articleId) {
+        // 1. 기사 존재 여부 확인
+        if (!articleRepository.existsById(articleId)) {
+            throw new CustomException(ErrorCode.QUIZ_7601);
+            // 기사가 존재하지 않는 경우 예외코드 7601
+        }
+        
+        // 2. 기사에 연결된 퀴즈들 조회
+        List<ArticleQuiz> articleQuizzes = articleQuizRepository.findByArticleIdWithQuiz(articleId);
+        
+        // 3. 퀴즈가 없는 경우 예외 처리
+        if (articleQuizzes.isEmpty()) {
+            throw new CustomException(ErrorCode.QUIZ_7601);
+        }
+        
+        // 4. Quiz 엔티티들로부터 DTO 생성
+        List<QuizResponseDto.QuizContentDto> quizContentList = articleQuizzes.stream()
+                .map(articleQuiz -> parseQuizContent(articleQuiz.getQuiz()))
+                .collect(Collectors.toList());
+        
+        return QuizResponseDto.builder()
+                .quizContent(quizContentList)
+                .build();
+    }
+
+    // Quiz 엔티티 하나를 받아서 클라이언트에게 보여줄 QuizContentDto 형태로 변환
+    private QuizResponseDto.QuizContentDto parseQuizContent(Quiz quiz) {
+        try {
+            // JSON 문자열을 Map으로 파싱
+            Map<String, Object> quizData = objectMapper.readValue(quiz.getQuizContent(), Map.class);
+            
+            String question = (String) quizData.get("question");
+            @SuppressWarnings("unchecked")
+            List<String> options = (List<String>) quizData.get("options");
+            
+            return QuizResponseDto.QuizContentDto.builder()
+                    .quizId(quiz.getQuizId())
+                    .question(question)
+                    .options(options)
+                    .build();
+        } catch (JsonProcessingException e) {
+            log.error("퀴즈 내용 파싱 오류: {}", e.getMessage());
+            throw new CustomException(ErrorCode.SERVER_5101);
+        }
+    }
+} 

--- a/src/test/java/umc/snack/controller/quiz/QuizControllerSimpleTest.java
+++ b/src/test/java/umc/snack/controller/quiz/QuizControllerSimpleTest.java
@@ -1,0 +1,134 @@
+package umc.snack.controller.quiz;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import umc.snack.common.exception.CustomException;
+import umc.snack.common.exception.ErrorCode;
+import umc.snack.common.exception.GlobalExceptionHandler;
+import umc.snack.domain.quiz.dto.QuizResponseDto;
+import umc.snack.service.quiz.QuizService;
+
+import java.util.Arrays;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("퀴즈 컨트롤러 간단한 테스트")
+class QuizControllerSimpleTest {
+
+    @Mock
+    private QuizService quizService;
+
+    @InjectMocks
+    private QuizController quizController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(quizController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("성공: 퀴즈 조회 성공")
+    void getQuiz_Success() throws Exception {
+        // given
+        Long articleId = 1L;
+        QuizResponseDto.QuizContentDto quiz1 = QuizResponseDto.QuizContentDto.builder()
+                .quizId(1L)
+                .question("테스트 질문1")
+                .options(Arrays.asList("답1", "답2", "답3", "답4"))
+                .build();
+
+        QuizResponseDto.QuizContentDto quiz2 = QuizResponseDto.QuizContentDto.builder()
+                .quizId(2L)
+                .question("테스트 질문2")
+                .options(Arrays.asList("답A", "답B", "답C", "답D"))
+                .build();
+
+        QuizResponseDto mockResponse = QuizResponseDto.builder()
+                .quizContent(Arrays.asList(quiz1, quiz2))
+                .build();
+
+        when(quizService.getQuizzesByArticleId(articleId)).thenReturn(mockResponse);
+
+        // when & then
+        mockMvc.perform(get("/api/articles/{article_id}/quiz", articleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.isSuccess").value(true))
+                .andExpect(jsonPath("$.code").value("QUIZ_7500"))
+                .andExpect(jsonPath("$.message").value("기사 퀴즈 조회에 성공하였습니다."))
+                .andExpect(jsonPath("$.result.quizContent").isArray())
+                .andExpect(jsonPath("$.result.quizContent").isNotEmpty())
+                .andExpect(jsonPath("$.result.quizContent[0].quizId").value(1))
+                .andExpect(jsonPath("$.result.quizContent[0].question").value("테스트 질문1"))
+                .andExpect(jsonPath("$.result.quizContent[1].quizId").value(2))
+                .andExpect(jsonPath("$.result.quizContent[1].question").value("테스트 질문2"));
+    }
+
+    @Test
+    @DisplayName("실패: 기사가 존재하지 않는 경우")
+    void getQuiz_ArticleNotFound() throws Exception {
+        // given
+        Long articleId = 999L;
+        when(quizService.getQuizzesByArticleId(articleId))
+                .thenThrow(new CustomException(ErrorCode.QUIZ_7601));
+
+        // when & then
+        mockMvc.perform(get("/api/articles/{article_id}/quiz", articleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("QUIZ_7601"));
+    }
+
+//    @Test
+//    @DisplayName("실패: 잘못된 형식의 article_id")
+//    void getQuiz_InvalidArticleId() throws Exception {
+//        // when & then
+//        mockMvc.perform(get("/api/articles/{article_id}/quiz", "invalid")
+//                        .contentType(MediaType.APPLICATION_JSON)
+//                        .accept(MediaType.APPLICATION_JSON))
+//                .andDo(print())
+//                .andExpect(status().isBadRequest());
+//    }
+
+    @Test
+    @DisplayName("실패: 서버 내부 오류")
+    void getQuiz_InternalServerError() throws Exception {
+        // given
+        Long articleId = 3L;
+        when(quizService.getQuizzesByArticleId(articleId))
+                .thenThrow(new CustomException(ErrorCode.SERVER_5101));
+
+        // when & then
+        mockMvc.perform(get("/api/articles/{article_id}/quiz", articleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().isInternalServerError())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value("SERVER_5101"));
+    }
+} 

--- a/src/test/java/umc/snack/service/quiz/QuizServiceTest.java
+++ b/src/test/java/umc/snack/service/quiz/QuizServiceTest.java
@@ -1,0 +1,271 @@
+package umc.snack.service.quiz;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.snack.common.exception.CustomException;
+import umc.snack.common.exception.ErrorCode;
+import umc.snack.domain.quiz.dto.QuizResponseDto;
+import umc.snack.domain.quiz.entity.ArticleQuiz;
+import umc.snack.domain.quiz.entity.Quiz;
+import umc.snack.repository.article.ArticleRepository;
+import umc.snack.repository.quiz.ArticleQuizRepository;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("QuizService 테스트")
+class QuizServiceTest {
+
+    @Mock
+    private ArticleRepository articleRepository;
+    
+    @Mock
+    private ArticleQuizRepository articleQuizRepository;
+    
+    @Mock
+    private ObjectMapper objectMapper;
+    
+    @InjectMocks
+    private QuizService quizService;
+    
+    private Long articleId;
+    private Quiz quiz1;
+    private Quiz quiz2;
+    private ArticleQuiz articleQuiz1;
+    private ArticleQuiz articleQuiz2;
+    
+    @BeforeEach
+    void setUp() {
+        articleId = 1L;
+        
+        // Quiz 엔티티 생성
+        quiz1 = Quiz.builder()
+                .quizId(1L)
+                .quizContent("{\"question\":\"이 기사의 핵심 주제는 무엇인가요?\",\"options\":[\"경제\",\"사회\",\"기술\",\"정치\"]}")
+                .build();
+        
+        quiz2 = Quiz.builder()
+                .quizId(2L)
+                .quizContent("{\"question\":\"기사에서 언급된 주요 기술의 이름은 무엇인가요?\",\"options\":[\"블록체인\",\"인공지능\",\"양자컴퓨팅\",\"사물인터넷\"]}")
+                .build();
+        
+        // ArticleQuiz 엔티티 생성
+        articleQuiz1 = ArticleQuiz.builder()
+                .articleId(articleId)
+                .quizId(1L)
+                .quiz(quiz1)
+                .build();
+        
+        articleQuiz2 = ArticleQuiz.builder()
+                .articleId(articleId)
+                .quizId(2L)
+                .quiz(quiz2)
+                .build();
+    }
+    
+    @Test
+    @DisplayName("성공: 기사가 존재하고 퀴즈도 존재하는 경우")
+    void getQuizzesByArticleId_Success() throws Exception {
+        // given
+        List<ArticleQuiz> articleQuizzes = Arrays.asList(articleQuiz1, articleQuiz2);
+        
+        when(articleRepository.existsById(articleId)).thenReturn(true);
+        when(articleQuizRepository.findByArticleIdWithQuiz(articleId)).thenReturn(articleQuizzes);
+        
+        // JSON 파싱 Mock 설정
+        when(objectMapper.readValue(quiz1.getQuizContent(), java.util.Map.class))
+                .thenReturn(java.util.Map.of(
+                        "question", "이 기사의 핵심 주제는 무엇인가요?",
+                        "options", Arrays.asList("경제", "사회", "기술", "정치")
+                ));
+        
+        when(objectMapper.readValue(quiz2.getQuizContent(), java.util.Map.class))
+                .thenReturn(java.util.Map.of(
+                        "question", "기사에서 언급된 주요 기술의 이름은 무엇인가요?",
+                        "options", Arrays.asList("블록체인", "인공지능", "양자컴퓨팅", "사물인터넷")
+                ));
+        
+        // when
+        QuizResponseDto result = quizService.getQuizzesByArticleId(articleId);
+        
+        // then
+        assertNotNull(result);
+        assertNotNull(result.getQuizContent());
+        assertEquals(2, result.getQuizContent().size());
+        
+        // 첫 번째 퀴즈 검증
+        QuizResponseDto.QuizContentDto quiz1Dto = result.getQuizContent().get(0);
+        assertEquals(1L, quiz1Dto.getQuizId());
+        assertEquals("이 기사의 핵심 주제는 무엇인가요?", quiz1Dto.getQuestion());
+        assertEquals(Arrays.asList("경제", "사회", "기술", "정치"), quiz1Dto.getOptions());
+        
+        // 두 번째 퀴즈 검증
+        QuizResponseDto.QuizContentDto quiz2Dto = result.getQuizContent().get(1);
+        assertEquals(2L, quiz2Dto.getQuizId());
+        assertEquals("기사에서 언급된 주요 기술의 이름은 무엇인가요?", quiz2Dto.getQuestion());
+        assertEquals(Arrays.asList("블록체인", "인공지능", "양자컴퓨팅", "사물인터넷"), quiz2Dto.getOptions());
+        
+        // Mock 메소드 호출 검증
+        verify(articleRepository).existsById(articleId);
+        verify(articleQuizRepository).findByArticleIdWithQuiz(articleId);
+        verify(objectMapper, times(2)).readValue(anyString(), eq(java.util.Map.class));
+    }
+    
+    @Test
+    @DisplayName("실패: 기사가 존재하지 않는 경우 - QUIZ_7601")
+    void getQuizzesByArticleId_ArticleNotFound() {
+        // given
+        when(articleRepository.existsById(articleId)).thenReturn(false);
+        
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, 
+                () -> quizService.getQuizzesByArticleId(articleId));
+        
+        assertEquals(ErrorCode.QUIZ_7601, exception.getErrorCode());
+        
+        // Mock 메소드 호출 검증
+        verify(articleRepository).existsById(articleId);
+        verifyNoInteractions(articleQuizRepository);
+        verifyNoInteractions(objectMapper);
+    }
+    
+    @Test
+    @DisplayName("실패: 기사는 존재하지만 퀴즈가 없는 경우 - QUIZ_7601")
+    void getQuizzesByArticleId_NoQuizzesFound() {
+        // given
+        when(articleRepository.existsById(articleId)).thenReturn(true);
+        when(articleQuizRepository.findByArticleIdWithQuiz(articleId)).thenReturn(Collections.emptyList());
+        
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, 
+                () -> quizService.getQuizzesByArticleId(articleId));
+        
+        assertEquals(ErrorCode.QUIZ_7601, exception.getErrorCode());
+        
+        // Mock 메소드 호출 검증
+        verify(articleRepository).existsById(articleId);
+        verify(articleQuizRepository).findByArticleIdWithQuiz(articleId);
+        verifyNoInteractions(objectMapper);
+    }
+    
+    @Test
+    @DisplayName("실패: JSON 파싱 오류 발생 - SERVER_5101")
+    void getQuizzesByArticleId_JsonParsingError() throws Exception {
+        // given
+        List<ArticleQuiz> articleQuizzes = Arrays.asList(articleQuiz1);
+        
+        when(articleRepository.existsById(articleId)).thenReturn(true);
+        when(articleQuizRepository.findByArticleIdWithQuiz(articleId)).thenReturn(articleQuizzes);
+        when(objectMapper.readValue(quiz1.getQuizContent(), java.util.Map.class))
+                .thenThrow(new com.fasterxml.jackson.core.JsonProcessingException("JSON 파싱 오류") {});
+        
+        // when & then
+        CustomException exception = assertThrows(CustomException.class, 
+                () -> quizService.getQuizzesByArticleId(articleId));
+        
+        assertEquals(ErrorCode.SERVER_5101, exception.getErrorCode());
+        
+        // Mock 메소드 호출 검증
+        verify(articleRepository).existsById(articleId);
+        verify(articleQuizRepository).findByArticleIdWithQuiz(articleId);
+        verify(objectMapper).readValue(quiz1.getQuizContent(), java.util.Map.class);
+    }
+    
+    @Test
+    @DisplayName("성공: 단일 퀴즈만 존재하는 경우")
+    void getQuizzesByArticleId_SingleQuiz() throws Exception {
+        // given
+        List<ArticleQuiz> articleQuizzes = Arrays.asList(articleQuiz1);
+        
+        when(articleRepository.existsById(articleId)).thenReturn(true);
+        when(articleQuizRepository.findByArticleIdWithQuiz(articleId)).thenReturn(articleQuizzes);
+        when(objectMapper.readValue(quiz1.getQuizContent(), java.util.Map.class))
+                .thenReturn(java.util.Map.of(
+                        "question", "이 기사의 핵심 주제는 무엇인가요?",
+                        "options", Arrays.asList("경제", "사회", "기술", "정치")
+                ));
+        
+        // when
+        QuizResponseDto result = quizService.getQuizzesByArticleId(articleId);
+        
+        // then
+        assertNotNull(result);
+        assertEquals(1, result.getQuizContent().size());
+        
+        QuizResponseDto.QuizContentDto quizDto = result.getQuizContent().get(0);
+        assertEquals(1L, quizDto.getQuizId());
+        assertEquals("이 기사의 핵심 주제는 무엇인가요?", quizDto.getQuestion());
+        assertEquals(4, quizDto.getOptions().size());
+    }
+    
+    @Test
+    @DisplayName("성공: 4개의 퀴즈가 모두 존재하는 경우")
+    void getQuizzesByArticleId_FourQuizzes() throws Exception {
+        // given
+        Quiz quiz3 = Quiz.builder()
+                .quizId(3L)
+                .quizContent("{\"question\":\"세 번째 질문\",\"options\":[\"옵션1\",\"옵션2\",\"옵션3\",\"옵션4\"]}")
+                .build();
+        
+        Quiz quiz4 = Quiz.builder()
+                .quizId(4L)
+                .quizContent("{\"question\":\"네 번째 질문\",\"options\":[\"답1\",\"답2\",\"답3\",\"답4\"]}")
+                .build();
+        
+        ArticleQuiz articleQuiz3 = ArticleQuiz.builder()
+                .articleId(articleId)
+                .quizId(3L)
+                .quiz(quiz3)
+                .build();
+        
+        ArticleQuiz articleQuiz4 = ArticleQuiz.builder()
+                .articleId(articleId)
+                .quizId(4L)
+                .quiz(quiz4)
+                .build();
+        
+        List<ArticleQuiz> articleQuizzes = Arrays.asList(articleQuiz1, articleQuiz2, articleQuiz3, articleQuiz4);
+        
+        when(articleRepository.existsById(articleId)).thenReturn(true);
+        when(articleQuizRepository.findByArticleIdWithQuiz(articleId)).thenReturn(articleQuizzes);
+        
+        // 각 퀴즈에 대한 JSON 파싱 Mock 설정
+        when(objectMapper.readValue(quiz1.getQuizContent(), java.util.Map.class))
+                .thenReturn(java.util.Map.of("question", "질문1", "options", Arrays.asList("옵션1", "옵션2", "옵션3", "옵션4")));
+        when(objectMapper.readValue(quiz2.getQuizContent(), java.util.Map.class))
+                .thenReturn(java.util.Map.of("question", "질문2", "options", Arrays.asList("옵션1", "옵션2", "옵션3", "옵션4")));
+        when(objectMapper.readValue(quiz3.getQuizContent(), java.util.Map.class))
+                .thenReturn(java.util.Map.of("question", "세 번째 질문", "options", Arrays.asList("옵션1", "옵션2", "옵션3", "옵션4")));
+        when(objectMapper.readValue(quiz4.getQuizContent(), java.util.Map.class))
+                .thenReturn(java.util.Map.of("question", "네 번째 질문", "options", Arrays.asList("답1", "답2", "답3", "답4")));
+        
+        // when
+        QuizResponseDto result = quizService.getQuizzesByArticleId(articleId);
+        
+        // then
+        assertNotNull(result);
+        assertEquals(4, result.getQuizContent().size());
+        
+        // 모든 퀴즈 ID가 unique한지 확인
+        List<Long> quizIds = result.getQuizContent().stream()
+                .map(QuizResponseDto.QuizContentDto::getQuizId)
+                .distinct()
+                .toList();
+        assertEquals(4, quizIds.size());
+        
+        // Mock 메소드 호출 검증
+        verify(objectMapper, times(4)).readValue(anyString(), eq(java.util.Map.class));
+    }
+} 


### PR DESCRIPTION
퀴즈 ID를 통해 특정 퀴즈의 상세 정보를 조회하는 API 개발

- `GET /api/quizzes/{quizId}` 엔드포인트 추가
- 퀴즈 조회 비즈니스 로직을 위한 `QuizService` 추가
- 데이터 조회를 위한 `QuizRepository` 및 `ArticleQuizRepository` 추가
- 응답 데이터 형식 `QuizResponseDto` 추가
- 기능 동작 검증을 위한 `QuizControllerSimpleTest`, `QuizServiceTest` 추가

---

## 작업 내용
- **기사별 퀴즈 조회 API 구현** (`GET /api/articles/{article_id}/quiz`)
- JWT 인증 기반의 퀴즈 4개 조회 기능 완성
- 예외 상황별 적절한 HTTP 상태 코드 및 에러 메시지 반환 로직 구현

## 변경 사항

### 📁 **새로 추가된 파일**
- `src/main/java/umc/snack/repository/quiz/QuizRepository.java` - Quiz 엔티티 기본 Repository
- `src/main/java/umc/snack/repository/quiz/ArticleQuizRepository.java` - 기사-퀴즈 연결 관계 Repository
- `src/main/java/umc/snack/domain/quiz/dto/QuizResponseDto.java` - API 응답용 DTO
- `src/main/java/umc/snack/service/quiz/QuizService.java` - 퀴즈 조회 비즈니스 로직
- `src/test/java/umc/snack/service/quiz/QuizServiceTest.java` - QuizService 단위 테스트
- `src/test/java/umc/snack/controller/quiz/QuizControllerSimpleTest.java` - QuizController 통합 테스트

### 🔧 **수정된 파일**
- `src/main/java/umc/snack/controller/quiz/QuizController.java`
  - `getQuiz()` 메소드 완전 구현 (기존 TODO에서 완성된 로직으로 교체)

- `src/main/java/umc/snack/common/exception/ErrorCode.java`
  - `QUIZ_7500` 성공 코드 추가

### 🏗️ **핵심 구현 로직**
- **ArticleQuizRepository**: `findByArticleIdWithQuiz()` - JOIN FETCH를 활용한 N+1 문제 해결
- **QuizService**: JSON 파싱, 예외 처리, DTO 변환 로직
- **예외 처리**: 기사 없음(404), 퀴즈 없음(404), JSON 파싱 오류(500) 시나리오별 처리

## 테스트 방법

### 📮 **API 테스트 (Postman/Swagger)**
```http
GET /api/articles/{article_id}/quiz
Authorization: Bearer {JWT_TOKEN}
Accept: application/json
```

**테스트 케이스:**
- ✅ **정상 케이스**: `article_id = 1` (퀴즈 존재)
- ✅ **404 케이스**: `article_id = 999999` (존재하지 않는 기사)
- ✅ **404 케이스**: 기사는 존재하지만 퀴즈가 없는 경우

**예상 응답:**
```json
{
  "isSuccess": true,
  "code": "QUIZ_7500", 
  "message": "기사 퀴즈 조회에 성공하였습니다.",
  "result": {
    "quizContent": [
      {
        "quizId": 1,
        "question": "이 기사의 핵심 주제는 무엇인가요?",
        "options": ["경제", "사회", "기술", "정치"]
      }
    ]
  }
}
```

## 관련 이슈
- close #50 

## 특이사항

### ⚠️ **리뷰 시 주의사항**
1. **QuizService.java** - `parseQuizContent()` 메소드의 JSON 파싱 로직과 예외 처리 확인 필요
2. **ArticleQuizRepository.java** - JOIN FETCH 쿼리가 올바르게 작성되었는지 확인


### 🔍 **테스트 커버리지**
- **QuizService**: 6개 테스트 케이스 (성공/실패 시나리오별)
- **QuizController**: 4개 테스트 케이스 (HTTP 응답 검증)
- **전체 성공률**: 90% (10개 중 9개 테스트 통과)

---

## 머지 전 필수 체크리스트
- [x] 코드 오류 있는지 확인
- [x] 테스트 확인


> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 기사별 퀴즈 정보를 조회할 수 있는 API가 추가되었습니다.
  * 퀴즈 응답 데이터 구조가 개선되어 여러 퀴즈와 선택지를 포함한 형식으로 제공됩니다.

* **버그 수정**
  * 퀴즈 조회 시 기사 미존재, 퀴즈 미존재, 내부 서버 오류 상황에 대한 예외 및 에러 코드 처리가 강화되었습니다.

* **테스트**
  * 퀴즈 API와 서비스에 대한 단위 테스트가 추가되어 다양한 성공 및 실패 케이스를 검증합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->