### PR TITLE
[Fix] quiz parsing structure 변경

### DIFF
--- a/src/main/java/umc/snack/service/quiz/QuizService.java
+++ b/src/main/java/umc/snack/service/quiz/QuizService.java
@@ -66,8 +66,14 @@ public class QuizService {
             Map<String, Object> quizData = objectMapper.readValue(quiz.getQuizContent(), Map.class);
             
             String question = (String) quizData.get("question");
+
+            // options가 객체 배열 형태이므로 text 필드만 추출
             @SuppressWarnings("unchecked")
-            List<String> options = (List<String>) quizData.get("options");
+            List<Map<String, Object>> optionObjects = (List<Map<String, Object>>) quizData.get("options");
+
+            List<String> options = optionObjects.stream()
+                    .map(option -> (String) option.get("text"))
+                    .collect(Collectors.toList());
             
             return QuizResponseDto.QuizContentDto.builder()
                     .quizId(quiz.getQuizId())
@@ -76,6 +82,9 @@ public class QuizService {
                     .build();
         } catch (JsonProcessingException e) {
             log.error("퀴즈 내용 파싱 오류: {}", e.getMessage());
+            throw new CustomException(ErrorCode.SERVER_5101);
+        } catch (ClassCastException e) {
+            log.error("퀴즈 JSON 구조 파싱 오류: {}", e.getMessage());
             throw new CustomException(ErrorCode.SERVER_5101);
         }
     }

--- a/src/main/java/umc/snack/service/quiz/QuizService.java
+++ b/src/main/java/umc/snack/service/quiz/QuizService.java
@@ -108,15 +108,20 @@ public class QuizService {
                 .map(ArticleQuiz::getQuizId)
                 .collect(Collectors.toSet());
         
+        log.info("ArticleId: {}, 기사에 속한 유효한 퀴즈 ID들: {}", articleId, validQuizIds);
+        
         // 4. 제출된 퀴즈 ID들이 모두 해당 기사에 속하는지 검증
 
         List<Long> submittedQuizIds = requestDto.getSubmittedAnswers().stream()
                 .map(QuizGradingRequestDto.SubmittedAnswer::getQuizId)
                 .collect(Collectors.toList());
 
+        log.info("사용자가 제출한 퀴즈 ID들: {}", submittedQuizIds);
+
         // 없으면 에러 반환
         for (Long submittedQuizId : submittedQuizIds) {
             if (!validQuizIds.contains(submittedQuizId)) {
+                log.error("유효하지 않은 퀴즈 ID 발견: {}. 유효한 ID들: {}", submittedQuizId, validQuizIds);
                 throw new CustomException(ErrorCode.QUIZ_7603);
             }
         }
@@ -145,9 +150,45 @@ public class QuizService {
             // JSON 문자열을 Map으로 파싱
             Map<String, Object> quizData = objectMapper.readValue(quiz.getQuizContent(), Map.class);
             
-            // 정답 인덱스와 설명 추출
-            int correctAnswerIndex = (Integer) quizData.get("answer_index");
-            String description = (String) quizData.get("description");
+            log.info("퀴즈 ID: {}, JSON 구조: {}", quiz.getQuizId(), quizData);
+            
+            // 정답 텍스트 추출
+            String answerText = (String) quizData.get("answer");
+            if (answerText == null) {
+                log.error("퀴즈 ID {}의 JSON에 answer 필드가 없습니다. 사용 가능한 키들: {}", 
+                         quiz.getQuizId(), quizData.keySet());
+                throw new CustomException(ErrorCode.SERVER_5101);
+            }
+            
+            // options에서 정답 텍스트와 일치하는 인덱스 찾기
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> options = (List<Map<String, Object>>) quizData.get("options");
+            if (options == null) {
+                log.error("퀴즈 ID {}의 JSON에 options 필드가 없습니다.", quiz.getQuizId());
+                throw new CustomException(ErrorCode.SERVER_5101);
+            }
+            
+            int correctAnswerIndex = -1;
+            for (Map<String, Object> option : options) {
+                String optionText = (String) option.get("text");
+                if (answerText.equals(optionText)) {
+                    correctAnswerIndex = (Integer) option.get("id");
+                    break;
+                }
+            }
+            
+            if (correctAnswerIndex == -1) {
+                log.error("퀴즈 ID {}에서 정답 텍스트 '{}'와 일치하는 옵션을 찾을 수 없습니다. 옵션들: {}", 
+                         quiz.getQuizId(), answerText, options);
+                throw new CustomException(ErrorCode.SERVER_5101);
+            }
+            
+            // 설명 추출
+            String description = (String) quizData.get("explanation");
+            if (description == null) {
+                log.warn("퀴즈 ID {}의 JSON에 explanation 필드가 없습니다. 기본값 사용", quiz.getQuizId());
+                description = "정답 해설이 없습니다.";
+            }
             
             // 채점 결과 계산
             boolean isCorrect = submittedAnswer.getSubmitted_answer_index() == correctAnswerIndex;

--- a/src/test/java/umc/snack/service/quiz/QuizServiceTest.java
+++ b/src/test/java/umc/snack/service/quiz/QuizServiceTest.java
@@ -84,17 +84,27 @@ class QuizServiceTest {
         when(articleRepository.existsById(articleId)).thenReturn(true);
         when(articleQuizRepository.findByArticleIdWithQuiz(articleId)).thenReturn(articleQuizzes);
         
-        // JSON 파싱 Mock 설정
+        // JSON 파싱 Mock 설정 - 실제 JSON 구조에 맞게 수정
         when(objectMapper.readValue(quiz1.getQuizContent(), java.util.Map.class))
                 .thenReturn(java.util.Map.of(
                         "question", "이 기사의 핵심 주제는 무엇인가요?",
-                        "options", Arrays.asList("경제", "사회", "기술", "정치")
+                        "options", Arrays.asList(
+                                java.util.Map.of("id", 1, "text", "경제"),
+                                java.util.Map.of("id", 2, "text", "사회"),
+                                java.util.Map.of("id", 3, "text", "기술"),
+                                java.util.Map.of("id", 4, "text", "정치")
+                        )
                 ));
         
         when(objectMapper.readValue(quiz2.getQuizContent(), java.util.Map.class))
                 .thenReturn(java.util.Map.of(
                         "question", "기사에서 언급된 주요 기술의 이름은 무엇인가요?",
-                        "options", Arrays.asList("블록체인", "인공지능", "양자컴퓨팅", "사물인터넷")
+                        "options", Arrays.asList(
+                                java.util.Map.of("id", 1, "text", "블록체인"),
+                                java.util.Map.of("id", 2, "text", "인공지능"),
+                                java.util.Map.of("id", 3, "text", "양자컴퓨팅"),
+                                java.util.Map.of("id", 4, "text", "사물인터넷")
+                        )
                 ));
         
         // when
@@ -194,7 +204,12 @@ class QuizServiceTest {
         when(objectMapper.readValue(quiz1.getQuizContent(), java.util.Map.class))
                 .thenReturn(java.util.Map.of(
                         "question", "이 기사의 핵심 주제는 무엇인가요?",
-                        "options", Arrays.asList("경제", "사회", "기술", "정치")
+                        "options", Arrays.asList(
+                                java.util.Map.of("id", 1, "text", "경제"),
+                                java.util.Map.of("id", 2, "text", "사회"),
+                                java.util.Map.of("id", 3, "text", "기술"),
+                                java.util.Map.of("id", 4, "text", "정치")
+                        )
                 ));
         
         // when
@@ -241,15 +256,35 @@ class QuizServiceTest {
         when(articleRepository.existsById(articleId)).thenReturn(true);
         when(articleQuizRepository.findByArticleIdWithQuiz(articleId)).thenReturn(articleQuizzes);
         
-        // 각 퀴즈에 대한 JSON 파싱 Mock 설정
+        // 각 퀴즈에 대한 JSON 파싱 Mock 설정 - 실제 JSON 구조에 맞게 수정
         when(objectMapper.readValue(quiz1.getQuizContent(), java.util.Map.class))
-                .thenReturn(java.util.Map.of("question", "질문1", "options", Arrays.asList("옵션1", "옵션2", "옵션3", "옵션4")));
+                .thenReturn(java.util.Map.of("question", "질문1", "options", Arrays.asList(
+                        java.util.Map.of("id", 1, "text", "옵션1"),
+                        java.util.Map.of("id", 2, "text", "옵션2"),
+                        java.util.Map.of("id", 3, "text", "옵션3"),
+                        java.util.Map.of("id", 4, "text", "옵션4")
+                )));
         when(objectMapper.readValue(quiz2.getQuizContent(), java.util.Map.class))
-                .thenReturn(java.util.Map.of("question", "질문2", "options", Arrays.asList("옵션1", "옵션2", "옵션3", "옵션4")));
+                .thenReturn(java.util.Map.of("question", "질문2", "options", Arrays.asList(
+                        java.util.Map.of("id", 1, "text", "옵션1"),
+                        java.util.Map.of("id", 2, "text", "옵션2"),
+                        java.util.Map.of("id", 3, "text", "옵션3"),
+                        java.util.Map.of("id", 4, "text", "옵션4")
+                )));
         when(objectMapper.readValue(quiz3.getQuizContent(), java.util.Map.class))
-                .thenReturn(java.util.Map.of("question", "세 번째 질문", "options", Arrays.asList("옵션1", "옵션2", "옵션3", "옵션4")));
+                .thenReturn(java.util.Map.of("question", "세 번째 질문", "options", Arrays.asList(
+                        java.util.Map.of("id", 1, "text", "옵션1"),
+                        java.util.Map.of("id", 2, "text", "옵션2"),
+                        java.util.Map.of("id", 3, "text", "옵션3"),
+                        java.util.Map.of("id", 4, "text", "옵션4")
+                )));
         when(objectMapper.readValue(quiz4.getQuizContent(), java.util.Map.class))
-                .thenReturn(java.util.Map.of("question", "네 번째 질문", "options", Arrays.asList("답1", "답2", "답3", "답4")));
+                .thenReturn(java.util.Map.of("question", "네 번째 질문", "options", Arrays.asList(
+                        java.util.Map.of("id", 1, "text", "답1"),
+                        java.util.Map.of("id", 2, "text", "답2"),
+                        java.util.Map.of("id", 3, "text", "답3"),
+                        java.util.Map.of("id", 4, "text", "답4")
+                )));
         
         // when
         QuizResponseDto result = quizService.getQuizzesByArticleId(articleId);


### PR DESCRIPTION
## 작업 내용
- quiz parsing structure 변경

## 변경 사항
- 파일 2개 변경

## 테스트 방법
<img width="1582" height="969" alt="스크린샷 2025-07-29 오전 9 54 00" src="https://github.com/user-attachments/assets/b7eba96f-01be-4892-b509-6b5ae28eb0a0" />
<img width="1582" height="969" alt="스크린샷 2025-07-29 오전 9 53 41" src="https://github.com/user-attachments/assets/8196952a-425b-4b94-9e97-788b12bda5ed" />


## 관련 이슈
- close #87 


---

## 머지 전 필수 체크리스트
- [x] 제목 형식 지켰음 (`[기능] ~`)
- [x] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] 마일스톤 지정 완료
- [x] Assignee 지정 완료
- [x] Reviewer 지정 완료
- [ ] GitHub Actions 테스트 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 퀴즈 옵션과 정답 파싱 방식이 개선되어, 옵션이 문자열 리스트 대신 객체 리스트로 처리됩니다.
  * JSON 구조 오류에 대한 예외 처리와 로깅이 추가되었습니다.
  * 정답 및 해설 필드 파싱 로직이 강화되어 누락 시 기본값을 제공합니다.

* **테스트**
  * 새로운 JSON 구조에 맞게 테스트 데이터가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->