### PR TITLE
[feat] 메모에서 기사로 리다이렉트하는 API 구현

### DIFF
--- a/src/main/java/umc/snack/domain/memo/dto/MemoResponseDto.java
+++ b/src/main/java/umc/snack/domain/memo/dto/MemoResponseDto.java
@@ -15,4 +15,9 @@ public class MemoResponseDto {
         private Long memoId;
         private String content;
     }
+
+    @Builder @Getter
+    public static class RedirectResultDto {
+        private String redirectUrl;
+    }
 }

--- a/src/main/java/umc/snack/service/memo/MemoCommandService.java
+++ b/src/main/java/umc/snack/service/memo/MemoCommandService.java
@@ -10,4 +10,6 @@ public interface MemoCommandService {
     MemoResponseDto.UpdateResultDto updateMemo(Long articleId, Long memoId, MemoRequestDto.UpdateDto request);
 
     void deleteMemo(Long articleId, Long memoID);
+
+    MemoResponseDto.RedirectResultDto redirectToArticle(Long memoId);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,10 @@ spring:
         access: 14400000
         refresh: 1209600000
 
+# 프론트엔드 URL 설정
+frontend:
+  url: ${FRONTEND_URL:https://your-frontend.com}
+
 server:
   port: 8080
 


### PR DESCRIPTION
## 작업 내용
- GET /api/memos/{memo_id}/redirect 엔드포인트 추가
- 마이페이지에서 메모 클릭 시 해당 기사로 리다이렉션 기능
- 메모 소유권 및 기사 연결 상태 검증 로직 포함
- 프론트엔드 URL 설정 및 테스트 코드 작성


## 변경 사항
'src/main/java/umc/snack/controller/memo/MemoRedirectController.java'
'src/test/java/umc/snack/controller/memo/MemoRedirectControllerTest.java'
'src/main/resources/application.yml'
'src/main/java/umc/snack/domain/memo/dto/MemoResponseDto.java'
'src/main/java/umc/snack/service/memo/MemoCommandService.java'
'src/main/java/umc/snack/service/memo/MemoCommandServiceImpl.java'

## 테스트 방법
- Postman, Swagger 등으로 어떻게 테스트했는지

## 관련 이슈
- close #101 


---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] 마일스톤 지정 완료
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료
- [ ] GitHub Actions 테스트 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**
