### PR TITLE
feat (feed) : 사용자 행동 로그 기반 카테고리 선호 점수 계산

### DIFF
--- a/src/main/java/umc/snack/converter/feed/UserPreferenceConverter.java
+++ b/src/main/java/umc/snack/converter/feed/UserPreferenceConverter.java
@@ -1,0 +1,32 @@
+package umc.snack.converter.feed;
+
+import org.springframework.stereotype.Component;
+import umc.snack.domain.feed.entity.Category;
+import umc.snack.domain.user.dto.UserCategoryScoreDto;
+
+@Component
+public class UserPreferenceConverter {
+    private static final double WEIGHT_SCRAP = 0.5;
+    private static final double WEIGHT_CLICK = 0.3;
+    private static final double WEIGHT_SEARCH = 0.2;
+
+    public UserCategoryScoreDto toUserCategoryScoreDto(Long userId, Category category,
+                                                       int[] counts, double totalScraps,
+                                                       double totalClicks, double totalSearches) {
+        // 각 행동점수 0~1 사이로 정규화
+        float scrapScore = (totalScraps == 0) ? 0 : (float) (counts[0] / totalScraps);
+        float clickScore = (totalClicks == 0) ? 0 : (float) (counts[1] / totalClicks);
+        float searchScore = (totalSearches == 0) ? 0 : (float) (counts[2] / totalSearches);
+
+        float behaviorScore = (float) ((scrapScore * WEIGHT_SCRAP) + (clickScore * WEIGHT_CLICK) + (searchScore * WEIGHT_SEARCH));
+
+        return UserCategoryScoreDto.builder()
+                .userId(userId)
+                .categoryId(category.getCategoryId())
+                .scrapScore(scrapScore)
+                .clickScore(clickScore)
+                .searchScore(searchScore)
+                .behaviorScore(behaviorScore)
+                .build();
+    }
+}

--- a/src/main/java/umc/snack/repository/feed/UserClickRepository.java
+++ b/src/main/java/umc/snack/repository/feed/UserClickRepository.java
@@ -1,0 +1,11 @@
+package umc.snack.repository.feed;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import umc.snack.domain.user.entity.UserClicks;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface UserClickRepository extends JpaRepository<UserClicks, Long> {
+    List<UserClicks> findByUserIdAndCreatedAtAfter(Long userId, LocalDateTime createdAt);
+}

--- a/src/main/java/umc/snack/repository/scrap/UserScrapRepository.java
+++ b/src/main/java/umc/snack/repository/scrap/UserScrapRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.snack.domain.user.entity.UserScrap;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 public interface UserScrapRepository extends JpaRepository<UserScrap, Long> {
@@ -14,4 +16,6 @@ public interface UserScrapRepository extends JpaRepository<UserScrap, Long> {
     Optional<UserScrap> findByUserIdAndArticleId(Long userId, Long articleId);
 
     Page<UserScrap> findAllByUserId(Long userId, Pageable pageable);
+
+    List<UserScrap> findByUserIdAndCreatedAtAfter(Long userId, LocalDateTime createdAt);
 }

--- a/src/main/java/umc/snack/service/feed/UserPreferenceService.java
+++ b/src/main/java/umc/snack/service/feed/UserPreferenceService.java
@@ -1,0 +1,69 @@
+package umc.snack.service.feed;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.snack.converter.feed.UserPreferenceConverter;
+import umc.snack.domain.feed.entity.Category;
+import umc.snack.domain.user.dto.UserCategoryScoreDto;
+import umc.snack.repository.article.ArticleRepository;
+import umc.snack.repository.feed.UserClickRepository;
+import umc.snack.repository.scrap.UserScrapRepository;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserPreferenceService {
+    private final UserScrapRepository userScrapRepository;
+    private final UserClickRepository userClickRepository;
+    private final ArticleRepository articleRepository;
+    private final UserPreferenceConverter userPreferenceConverter;
+
+    private static final double WEIGHT_SCRAP = 0.5;
+    private static final double WEIGHT_CLICK = 0.3;
+    private static final double WEIGHT_SEARCH = 0.2;
+    private static final int RECENT_DAYS = 30;
+
+    public List<UserCategoryScoreDto> calculateCategoryScores(Long userId) {
+        LocalDateTime threshold = LocalDateTime.now().minusDays(RECENT_DAYS);
+
+        // category 별 행동 횟수 집계
+        Map<Category, int[]> categoryActionCounts = new HashMap<>();
+
+        userScrapRepository.findByUserIdAndCreatedAtAfter(userId, threshold).forEach(scrap -> {
+            scrap.getArticle().getArticleCategories().forEach(ac -> {
+                categoryActionCounts.computeIfAbsent(ac.getCategory(), k -> new int[3])[0]++;
+            });
+        });
+
+        userClickRepository.findByUserIdAndCreatedAtAfter(userId, threshold).forEach(scrap -> {
+            scrap.getArticle().getArticleCategories().forEach(ac -> {
+                categoryActionCounts.computeIfAbsent(ac.getCategory(), k -> new int [3])[1]++;
+            });
+        });
+
+        // 전체 행동 횟수 계산
+        double totalScraps = categoryActionCounts.values().stream().mapToInt(c -> c[0]).sum();
+        double totalClicks = categoryActionCounts.values().stream().mapToInt(c -> c[1]).sum();
+        double totalSearches = categoryActionCounts.values().stream().mapToInt(c -> c[2]).sum();
+
+        return categoryActionCounts.entrySet().stream()
+                .map(categoryEntry -> userPreferenceConverter.toUserCategoryScoreDto(
+                        userId,
+                        categoryEntry.getKey(),
+                        categoryEntry.getValue(),
+                        totalScraps,
+                        totalClicks,
+                        totalSearches
+                )) .sorted(Comparator.comparing(UserCategoryScoreDto::getBehaviorScore).reversed())
+                .limit(3)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/test/java/umc/snack/service/feed/UserPreferenceServiceTest.java
+++ b/src/test/java/umc/snack/service/feed/UserPreferenceServiceTest.java
@@ -1,0 +1,124 @@
+package umc.snack.service.feed;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import umc.snack.converter.feed.UserPreferenceConverter;
+import umc.snack.domain.article.entity.Article;
+import umc.snack.domain.article.entity.ArticleCategory;
+import umc.snack.domain.feed.entity.Category;
+import umc.snack.domain.user.dto.UserCategoryScoreDto;
+import umc.snack.domain.user.entity.UserClicks;
+import umc.snack.domain.user.entity.UserScrap;
+import umc.snack.repository.feed.UserClickRepository;
+import umc.snack.repository.scrap.UserScrapRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class UserPreferenceServiceTest {
+
+    // @InjectMocks는 생성자 주입을 사용하므로, Converter도 주입 대상에 포함시켜야 합니다.
+    // 여기서는 간단하게 Mock으로 처리합니다.
+    @Mock
+    private UserPreferenceConverter userPreferenceConverter;
+
+    @InjectMocks
+    private UserPreferenceService userPreferenceService;
+
+    @Mock
+    private UserScrapRepository userScrapRepository;
+
+    @Mock
+    private UserClickRepository userClickRepository;
+
+    @Test
+    @DisplayName("사용자 행동 로그 기반 카테고리 선호도 점수 계산 테스트")
+    void calculateCategoryScoresTest() {
+        // given: 테스트를 위한 가짜 데이터 설정
+        Long testUserId = 1L;
+
+        Category itCategory = Category.builder().categoryId(1L).categoryName("IT/과학").build();
+        Category economyCategory = Category.builder().categoryId(2L).categoryName("경제").build();
+
+        // 행동 데이터 설정: IT 스크랩 2번, 경제 클릭 1번
+        List<UserScrap> scraps = List.of(
+                createMockScrapWithCategory(itCategory),
+                createMockScrapWithCategory(itCategory)
+        );
+        List<UserClicks> clicks = List.of(
+                createMockClickWithCategory(economyCategory)
+        );
+
+        // Repository가 올바른 메서드를 호출받으면 위에서 만든 가짜 데이터를 반환하도록 설정
+        when(userScrapRepository.findByUserIdAndCreatedAtAfter(anyLong(), any(LocalDateTime.class)))
+                .thenReturn(scraps);
+        when(userClickRepository.findByUserIdAndCreatedAtAfter(anyLong(), any(LocalDateTime.class)))
+                .thenReturn(clicks);
+
+        // Converter가 호출될 때의 동작도 정의해줍니다. (실제 로직을 테스트하기 위함)
+        // 이 부분은 실제 UserPreferenceConverter의 로직을 그대로 가져와서 테스트용으로 만듭니다.
+        when(userPreferenceConverter.toUserCategoryScoreDto(anyLong(), any(Category.class), any(int[].class), any(Double.class), any(Double.class), any(Double.class)))
+                .thenAnswer(invocation -> {
+                    Long userId = invocation.getArgument(0);
+                    Category category = invocation.getArgument(1);
+                    int[] counts = invocation.getArgument(2);
+                    double totalScraps = invocation.getArgument(3);
+                    double totalClicks = invocation.getArgument(4);
+                    // ... 실제 컨버터 로직과 동일하게 점수 계산 ...
+                    float scrapScore = (totalScraps == 0) ? 0 : (float) (counts[0] / totalScraps);
+                    float clickScore = (totalClicks == 0) ? 0 : (float) (counts[1] / totalClicks);
+                    float behaviorScore = (float) ((scrapScore * 0.5) + (clickScore * 0.3));
+                    return UserCategoryScoreDto.builder().userId(userId).categoryId(category.getCategoryId()).behaviorScore(behaviorScore).categoryId(category.getCategoryId()).build();
+                });
+
+        // when: 테스트하려는 메서드 호출
+        List<UserCategoryScoreDto> result = userPreferenceService.calculateCategoryScores(testUserId);
+
+        // then: 결과 검증
+        assertThat(result).hasSize(2);
+
+        UserCategoryScoreDto topCategory = result.get(0);
+        assertThat(topCategory.getCategoryId()).isEqualTo(1L);
+        assertThat(topCategory.getBehaviorScore()).isEqualTo(0.5f);
+
+        UserCategoryScoreDto secondCategory = result.get(1);
+        assertThat(secondCategory.getCategoryId()).isEqualTo(2L);
+        assertThat(secondCategory.getBehaviorScore()).isEqualTo(0.3f);
+    }
+
+    // 테스트용 Mock 객체 생성을 위한 헬퍼 메서드 (내용 구현)
+    private UserScrap createMockScrapWithCategory(Category category) {
+        Article mockArticle = mock(Article.class);
+        ArticleCategory mockArticleCategory = mock(ArticleCategory.class);
+        UserScrap mockScrap = mock(UserScrap.class);
+
+        when(mockArticleCategory.getCategory()).thenReturn(category);
+        when(mockArticle.getArticleCategories()).thenReturn(List.of(mockArticleCategory));
+        when(mockScrap.getArticle()).thenReturn(mockArticle);
+
+        return mockScrap;
+    }
+
+    private UserClicks createMockClickWithCategory(Category category) {
+        Article mockArticle = mock(Article.class);
+        ArticleCategory mockArticleCategory = mock(ArticleCategory.class);
+        UserClicks mockClick = mock(UserClicks.class);
+
+        when(mockArticleCategory.getCategory()).thenReturn(category);
+        when(mockArticle.getArticleCategories()).thenReturn(List.of(mockArticleCategory));
+        when(mockClick.getArticle()).thenReturn(mockArticle);
+
+        return mockClick;
+    }
+}


### PR DESCRIPTION
## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- 사용자 행동 로그 기반 카테고리 선호 점수 계산 기능 구현
- 검색어 -> 카테고리 분류 하는 로직이 아직 안짜여있어서, 일단은 검색어 부분은 점수만 계산하도록 구현 (추가 예정)

## 변경 사항
- src/main/java/umc/snack/service/feed/UserPreferenceService.java

## 테스트 방법
- UnitTest
- 가짜 행동 로그(스크랩, 클릭) 을 주면 제대로 행동 점수 계산하는지 확인
behavior_score = 0.5 * 스크랩 + 0.3 * 클릭 + 0.2 * 검색 키워드
IT 2번 스크랩, 경제 1번 클릭한 경우, 상위 첫번째 선호 카테고리 점수 = 0.5 * 2 + 0.3 * 0 + 0.2 * 0 = 0.5 (IT/과학). 상위 두번째 선호 카테고리 점수 = 0.5 * 0 + 0.3 * 1 + 0.2 * 0 = 0.3 
 
<img width="1680" height="1026" alt="image" src="https://github.com/user-attachments/assets/b7e95aae-3ac7-4394-9ed2-6823795b9114" />


## 관련 이슈
- close #100 

## 특이사항
- 리뷰 시 반드시 봐야 하는 부분이 있다면 X

---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자의 최근 행동(스크랩, 클릭 등)을 기반으로 카테고리별 선호 점수를 계산하여 상위 3개 카테고리를 추천하는 기능이 추가되었습니다.

* **버그 수정**
  * 해당 없음

* **테스트**
  * 사용자 선호도 산정 서비스의 동작을 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->