### PR TITLE
feat (feed) : 메인피드 무한스크롤 테스트 코드 추가

### DIFF
--- a/src/main/java/umc/snack/SnackApplication.java
+++ b/src/main/java/umc/snack/SnackApplication.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
-@EnableJpaAuditing
+// @EnableJpaAuditing
 @EnableScheduling
 public class SnackApplication {
 

--- a/src/main/java/umc/snack/common/config/JpaConfig.java
+++ b/src/main/java/umc/snack/common/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package umc.snack.common.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/umc/snack/controller/feed/FeedController.java
+++ b/src/main/java/umc/snack/controller/feed/FeedController.java
@@ -25,7 +25,7 @@ public class FeedController {
             @Parameter(name = "category", description = "조회할 카테고리 이름 (예: IT/과학)", required = true),
             @Parameter(name = "lastArticleId", description = "마지막으로 조회한 기사의 ID. 첫번째 조회시에는 생략")
     })
-    @GetMapping("/main/{category}")
+    @GetMapping("/main")
     public ApiResponse<ArticleInFeedDto> getMainFeedArticles(
             @RequestParam String category,
             @RequestParam(required = false) Long lastArticleId,

--- a/src/main/java/umc/snack/converter/feed/UserPreferenceConverter.java
+++ b/src/main/java/umc/snack/converter/feed/UserPreferenceConverter.java
@@ -10,6 +10,7 @@ public class UserPreferenceConverter {
     private static final double WEIGHT_CLICK = 0.3;
     private static final double WEIGHT_SEARCH = 0.2;
 
+
     public UserCategoryScoreDto toUserCategoryScoreDto(Long userId, Category category,
                                                        int[] counts, double totalScraps,
                                                        double totalClicks, double totalSearches) {

--- a/src/test/java/umc/snack/controller/feed/FeedControllerTest.java
+++ b/src/test/java/umc/snack/controller/feed/FeedControllerTest.java
@@ -1,0 +1,80 @@
+package umc.snack.controller.feed;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import umc.snack.domain.feed.dto.ArticleInFeedDto;
+import umc.snack.domain.feed.dto.IndividualArticleDto;
+import umc.snack.service.feed.FeedService;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FeedController.class)
+class FeedControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private FeedService feedService;
+
+    @Test
+    @DisplayName("카테고리별 피드 첫 페이지 조회 성공")
+    @WithMockUser
+    void getMainFeedArticles_firstPage_success() throws Exception {
+        // given
+        String category = "IT/과학";
+        ArticleInFeedDto mockResponse = ArticleInFeedDto.builder()
+                .category("IT/과학")
+                .hasNext(true)
+                .nextCursorId(100L)
+                .articles(Collections.singletonList(
+                        IndividualArticleDto.builder().articleId(100L).title("테스트 기사").build()
+                ))
+                .build();
+
+        given(feedService.getMainFeedByCategory(eq(category), eq(null), any())).willReturn(mockResponse);
+
+        // when & then: URL에서 {category} 제거, .param()으로 추가
+        mockMvc.perform(get("/api/feeds/main")
+                        .param("category", category))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.category").value("IT/과학"));
+    }
+
+    @Test
+    @DisplayName("카테고리별 피드 다음 페이지 조회 성공 (커서 사용)")
+    @WithMockUser
+    void getMainFeedArticles_nextPage_success() throws Exception {
+        // given
+        String category = "경제";
+        Long lastArticleId = 100L;
+        ArticleInFeedDto mockResponse = ArticleInFeedDto.builder()
+                .category("경제")
+                .hasNext(false)
+                .nextCursorId(null)
+                .articles(Collections.emptyList())
+                .build();
+
+        given(feedService.getMainFeedByCategory(eq(category), eq(lastArticleId), any())).willReturn(mockResponse);
+
+        // when & then: URL에서 {category} 제거, .param()으로 추가
+        mockMvc.perform(get("/api/feeds/main")
+                        .param("category", category)
+                        .param("lastArticleId", String.valueOf(lastArticleId)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.category").value("경제"));
+    }
+}

--- a/src/test/java/umc/snack/controller/memo/MemoRedirectControllerTest.java
+++ b/src/test/java/umc/snack/controller/memo/MemoRedirectControllerTest.java
@@ -16,6 +16,8 @@ import umc.snack.repository.article.ArticleRepository;
 import umc.snack.repository.memo.MemoRepository;
 import umc.snack.repository.user.UserRepository;
 
+import java.time.LocalDateTime;
+
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -58,9 +60,9 @@ public class MemoRedirectControllerTest {
         // 테스트 기사 생성
         testArticle = Article.builder()
                 .title("테스트 기사")
-                .content("테스트 기사 내용")
-                .url("https://test.com/article")
-                .publishedAt("2024-01-01T00:00:00")
+                .summary("테스트 기사 내용")
+                .articleUrl("https://test.com/article")
+                .publishedAt(LocalDateTime.parse("2024-01-01T00:00:00"))
                 .build();
         testArticle = articleRepository.save(testArticle);
 


### PR DESCRIPTION
## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- 메인피드에서 무한스크롤 잘 되는지 확인하는 UnitTest 코드 추가 및 FeedController 수정

## 변경 사항
- src/test/java/umc/snack/controller/feed/FeedControllerTest.java
- src/main/java/umc/snack/controller/feed/FeedController.java

## 테스트 방법
- 컨트롤러 테스트
<img width="1680" height="1026" alt="image" src="https://github.com/user-attachments/assets/f4cc6dd1-7e12-4e5a-bf26-d2c78d01bc4f" />

## 관련 이슈
- close #105 

## 특이사항
- `Caused by: java.lang.IllegalArgumentException: JPA metamodel must not be empty` 오류 발생 -> @WebMvcTest 환경에서 JPA Auditing 빈 초기화 충돌을 해결하기 위해 @EnableJpaAuditing을 별도 JpaConfig로 분리했습니다.
- `src/test/java/umc/snack/controller/memo/MemoRedirectControllerTest.java` -> Column 명 달라서 오류 발생하길래 수정했습니다.

---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 피드 메인 조회 엔드포인트가 경로 변수에서 쿼리 파라미터 방식으로 변경되었습니다. 이제 카테고리는 쿼리 파라미터로 전달해야 합니다.

* **테스트**
  * 피드 컨트롤러의 주요 피드 조회 기능에 대한 단위 테스트가 추가되었습니다.
  * 메모 리다이렉트 컨트롤러 테스트에서 Article 엔티티의 필드명 및 타입이 변경된 부분이 반영되었습니다.

* **기타**
  * JPA 감사 기능 활성화 위치가 애플리케이션 클래스에서 별도 설정 클래스로 이동되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->