### PR TITLE
feat (memo) : 메모 목록 조회 구현

### DIFF
--- a/src/main/java/umc/snack/controller/memo/MemoController.java
+++ b/src/main/java/umc/snack/controller/memo/MemoController.java
@@ -1,5 +1,6 @@
 package umc.snack.controller.memo;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,8 @@ import umc.snack.common.dto.ApiResponse;
 import umc.snack.domain.memo.dto.MemoRequestDto;
 import umc.snack.domain.memo.dto.MemoResponseDto;
 import umc.snack.service.memo.MemoCommandService;
+import umc.snack.service.memo.MemoQueryService;
+import umc.snack.service.memo.MemoQueryServiceImpl;
 
 @RestController
 @RequestMapping("/api/articles/{article_id}/memos")
@@ -17,6 +20,8 @@ import umc.snack.service.memo.MemoCommandService;
 @Tag(name = "Memo", description = "기사 메모 관련 API")
 public class MemoController {
     private final MemoCommandService memoCommandService;
+    private final MemoQueryService memoQueryService;
+
     @Operation(summary = "특정 기사에 메모 작성", description = "현재 보고 있는 기사에 대한 메모를 작성하는 API입니다.")
     @PostMapping
     public ApiResponse<MemoResponseDto.CreateResultDto> createMemo (
@@ -70,5 +75,16 @@ public class MemoController {
         );
     }
 
+    @Operation(summary = "사용자 작성 메모 목록 조회", description = "로그인한 사용자가 작성한 모든 메모 목록을 최신순으로 페이징하여 조회합니다.")
+    @GetMapping("/memos")
+    public ApiResponse<MemoResponseDto.MemoListDto> getMemoByUser(
+            @RequestParam(defaultValue = "0") @Parameter(description = "조회할 페이지 번호", example = "0") int page,
+            @RequestParam(defaultValue = "10") @Parameter(description = "한 페이지에 보여줄 메모 개수", example = "10") int size,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+        Long userId = customUserDetails.getUserId();
 
+        MemoResponseDto.MemoListDto resultDto = memoQueryService.getMemosByUser(userId, page, size);
+
+        return ApiResponse.onSuccess("MEMO_8504", "메모 목록을 조회했습니다.", resultDto);
+    }
 }

--- a/src/main/java/umc/snack/converter/memo/MemoConverter.java
+++ b/src/main/java/umc/snack/converter/memo/MemoConverter.java
@@ -1,10 +1,12 @@
 package umc.snack.converter.memo;
 
 import org.springframework.data.domain.Page;
+import umc.snack.domain.article.entity.Article;
 import umc.snack.domain.memo.dto.MemoResponseDto;
 import umc.snack.domain.memo.entity.Memo;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 public class MemoConverter {
@@ -23,6 +25,11 @@ public class MemoConverter {
     }
 
     public static MemoResponseDto.MemoInfo toMemoInfo(Memo memo) {
+
+        String articleUrl = Optional.ofNullable(memo.getArticle())
+                .map(Article::getArticleUrl)
+                .orElse(null); // 기사가 없는 메모는 articleUrl을 null로 설정
+
         return MemoResponseDto.MemoInfo.builder()
                 .memoId(memo.getMemoId())
                 .content(memo.getContent())

--- a/src/main/java/umc/snack/converter/memo/MemoConverter.java
+++ b/src/main/java/umc/snack/converter/memo/MemoConverter.java
@@ -1,7 +1,11 @@
 package umc.snack.converter.memo;
 
+import org.springframework.data.domain.Page;
 import umc.snack.domain.memo.dto.MemoResponseDto;
 import umc.snack.domain.memo.entity.Memo;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class MemoConverter {
     public static MemoResponseDto.CreateResultDto toCreateResultDto(Memo memo) {
@@ -15,6 +19,29 @@ public class MemoConverter {
         return MemoResponseDto.UpdateResultDto.builder()
                 .memoId(memo.getMemoId())
                 .content(memo.getContent())
+                .build();
+    }
+
+    public static MemoResponseDto.MemoInfo toMemoInfo(Memo memo) {
+        return MemoResponseDto.MemoInfo.builder()
+                .memoId(memo.getMemoId())
+                .content(memo.getContent())
+                .createdAt(memo.getCreatedAt())
+                .articleUrl(memo.getArticle().getArticleUrl())
+                .build();
+    }
+
+    public static MemoResponseDto.MemoListDto toMemoListDto(Page<Memo> memoPage) {
+        List<MemoResponseDto.MemoInfo> memoInfos = memoPage.getContent().stream()
+                .map(MemoConverter::toMemoInfo)
+                .collect(Collectors.toList());
+
+        return MemoResponseDto.MemoListDto.builder()
+                .memos(memoInfos)
+                .page(memoPage.getNumber())
+                .size(memoPage.getSize())
+                .totalPages(memoPage.getTotalPages())
+                .totalElements(memoPage.getTotalElements())
                 .build();
     }
 }

--- a/src/main/java/umc/snack/domain/memo/dto/MemoResponseDto.java
+++ b/src/main/java/umc/snack/domain/memo/dto/MemoResponseDto.java
@@ -1,23 +1,46 @@
 package umc.snack.domain.memo.dto;
 
+import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public class MemoResponseDto {
-    @Builder @Getter
+    @Builder @Getter @NoArgsConstructor @AllArgsConstructor
     public static class CreateResultDto {
         private Long memoId;
         private String content;
     }
 
-    @Builder @Getter
+    @Builder @Getter @NoArgsConstructor @AllArgsConstructor
     public static class UpdateResultDto {
         private Long memoId;
         private String content;
     }
 
-    @Builder @Getter
+    @Builder @Getter @NoArgsConstructor @AllArgsConstructor
     public static class RedirectResultDto {
         private String redirectUrl;
     }
+
+    @Builder @Getter @NoArgsConstructor @AllArgsConstructor
+    public static class MemoInfo {
+        private Long memoId;
+        private String content;
+        private LocalDateTime createdAt;
+        private String articleUrl;
+    }
+
+    @Builder @Getter @NoArgsConstructor @AllArgsConstructor
+    public static class MemoListDto {
+        private List<MemoInfo> memos;
+        private int page;
+        private int size;
+        private int totalPages;
+        private long totalElements;
+    }
+
 }

--- a/src/main/java/umc/snack/domain/memo/entity/Memo.java
+++ b/src/main/java/umc/snack/domain/memo/entity/Memo.java
@@ -26,7 +26,7 @@ public class Memo extends BaseEntity {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "article_id")
+    @JoinColumn(name = "article_id", nullable = false)
     private Article article;
 
     @Column(nullable = false, length = 200)

--- a/src/main/java/umc/snack/repository/memo/MemoRepository.java
+++ b/src/main/java/umc/snack/repository/memo/MemoRepository.java
@@ -1,7 +1,10 @@
 package umc.snack.repository.memo;
 
+import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.snack.domain.memo.entity.Memo;
-
+import umc.snack.domain.user.entity.User;
+import org.springframework.data.domain.Pageable;
 public interface MemoRepository extends JpaRepository<Memo, Long> {
+    Page<Memo> findByUser(User user, Pageable pageable);
 }

--- a/src/main/java/umc/snack/service/memo/MemoQueryService.java
+++ b/src/main/java/umc/snack/service/memo/MemoQueryService.java
@@ -1,0 +1,7 @@
+package umc.snack.service.memo;
+
+import umc.snack.domain.memo.dto.MemoResponseDto;
+
+public interface MemoQueryService {
+    MemoResponseDto.MemoListDto getMemosByUser(Long userId, int page, int size);
+}

--- a/src/main/java/umc/snack/service/memo/MemoQueryServiceImpl.java
+++ b/src/main/java/umc/snack/service/memo/MemoQueryServiceImpl.java
@@ -1,0 +1,40 @@
+package umc.snack.service.memo;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import umc.snack.common.exception.CustomException;
+import umc.snack.common.exception.ErrorCode;
+import umc.snack.converter.memo.MemoConverter;
+import umc.snack.domain.memo.dto.MemoResponseDto;
+import umc.snack.domain.memo.entity.Memo;
+import umc.snack.domain.user.entity.User;
+import umc.snack.repository.memo.MemoRepository;
+import umc.snack.repository.user.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemoQueryServiceImpl implements MemoQueryService {
+    private final MemoRepository memoRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    public MemoResponseDto.MemoListDto getMemosByUser(Long userId, int page, int size) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_2622));
+
+        Pageable pageable = PageRequest.of(page, size, Sort.by("createdAt").descending());
+
+        Page<Memo> memoPage = memoRepository.findByUser(user, pageable);
+
+        if (memoPage.isEmpty() && page > 0)
+            throw new CustomException(ErrorCode.REQ_3104);
+
+        return MemoConverter.toMemoListDto(memoPage);
+    }
+}


### PR DESCRIPTION
## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- 메모 목록 조회 구현

## 변경 사항
- src/main/java/umc/snack/service/memo/MemoQueryServiceImpl.java

## 테스트 방법
- 스웨거
<img width="1434" height="1067" alt="스크린샷 2025-08-01 오전 6 18 40" src="https://github.com/user-attachments/assets/56445e93-d3df-4f97-b6c7-33f47bee56aa" />
<img width="1478" height="1111" alt="스크린샷 2025-08-01 오전 6 20 06" src="https://github.com/user-attachments/assets/4af118ec-0cf0-4579-b68a-480deb46a5bb" />


## 관련 이슈
- close #118 

## 특이사항
- 리뷰 시 반드시 봐야 하는 부분이 있다면

---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 현재 로그인한 사용자가 작성한 메모 목록을 페이지네이션 형태로 조회할 수 있는 API 엔드포인트가 추가되었습니다.
  * 메모 목록 조회 시 각 메모의 생성일시, 본문, 연결된 아티클 URL 등 상세 정보와 함께 페이지, 전체 페이지 수, 전체 개수 등의 페이징 정보가 제공됩니다.

* **문서화**
  * 신규 API 엔드포인트 및 파라미터에 대한 Swagger 문서가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->