### PR TITLE
refactor(memo) : 메모 리스트 조회 api 경로 수정

### DIFF
--- a/src/main/java/umc/snack/controller/memo/MemoController.java
+++ b/src/main/java/umc/snack/controller/memo/MemoController.java
@@ -74,7 +74,7 @@ public class MemoController {
                 null
         );
     }
-
+/*
     @Operation(summary = "사용자 작성 메모 목록 조회", description = "로그인한 사용자가 작성한 모든 메모 목록을 최신순으로 페이징하여 조회합니다.")
     @GetMapping("/memos")
     public ApiResponse<MemoResponseDto.MemoListDto> getMemoByUser(
@@ -87,4 +87,6 @@ public class MemoController {
 
         return ApiResponse.onSuccess("MEMO_8504", "메모 목록을 조회했습니다.", resultDto);
     }
+
+ */
 }

--- a/src/main/java/umc/snack/controller/memo/MyMemoController.java
+++ b/src/main/java/umc/snack/controller/memo/MyMemoController.java
@@ -1,0 +1,29 @@
+package umc.snack.controller.memo;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import umc.snack.common.config.security.CustomUserDetails;
+import umc.snack.common.dto.ApiResponse;
+import umc.snack.domain.memo.dto.MemoResponseDto;
+import umc.snack.service.memo.MemoQueryService;
+@RestController
+@RequestMapping("/api/memos")
+@RequiredArgsConstructor
+@Tag(name = "Memo", description = "기사 메모 관련 API")
+public class MyMemoController {
+    private final MemoQueryService memoQueryService;
+
+    @Operation(summary = "내가 작성한 메모 목록 조회")
+    @GetMapping("")
+    public ApiResponse<MemoResponseDto.MemoListDto> getMyMemos(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long userId = customUserDetails.getUserId();
+        MemoResponseDto.MemoListDto resultDto = memoQueryService.getMemosByUser(userId, page, size);
+        return ApiResponse.onSuccess("MEMO_8504", "내 메모 목록을 성공적으로 조회했습니다.", resultDto);
+    }
+}


### PR DESCRIPTION
## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- 메모 리스트 조회 api 경로 수정

## 변경 사항
- src/main/java/umc/snack/controller/memo/MyMemoController.java

## 테스트 방법
- Swagger 
<img width="1680" height="1026" alt="스크린샷 2025-08-02 오후 11 38 40" src="https://github.com/user-attachments/assets/7abad5d3-fa32-43f1-9f0d-c1670bc312c3" />
<img width="1680" height="1026" alt="스크린샷 2025-08-02 오후 11 38 23" src="https://github.com/user-attachments/assets/c4702b0c-d693-4000-956c-3709e3a5fda1" />
<img width="1680" height="1026" alt="스크린샷 2025-08-02 오후 11 38 33" src="https://github.com/user-attachments/assets/5e9c33aa-9bb4-41fe-89fd-f0adc84780d3" />

## 관련 이슈
- close #131 

## 특이사항
- 리뷰 시 반드시 봐야 하는 부분이 있다면

---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**
