### PR TITLE
[feat] 회원탈퇴 API 구현

### DIFF
--- a/src/main/java/umc/snack/common/config/SecurityConfig.java
+++ b/src/main/java/umc/snack/common/config/SecurityConfig.java
@@ -17,6 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+import umc.snack.common.config.security.CustomAuthenticationEntryPoint;
 import umc.snack.common.config.security.jwt.JWTFilter;
 import umc.snack.common.config.security.jwt.JWTUtil;
 import umc.snack.common.config.security.jwt.LoginFilter;
@@ -34,13 +35,15 @@ public class SecurityConfig {
     private final JWTUtil jwtUtil;
     private final RefreshTokenRepository refreshTokenRepository;
     private final ReissueService reissueService;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
-    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil, ReissueService reissueService ,RefreshTokenRepository refreshTokenRepository) {
+    public SecurityConfig(AuthenticationConfiguration authenticationConfiguration, JWTUtil jwtUtil, ReissueService reissueService ,RefreshTokenRepository refreshTokenRepository, CustomAuthenticationEntryPoint customAuthenticationEntryPoint) {
 
         this.authenticationConfiguration = authenticationConfiguration;
         this.jwtUtil = jwtUtil;
         this.refreshTokenRepository = refreshTokenRepository;
         this.reissueService = reissueService;
+        this.customAuthenticationEntryPoint = customAuthenticationEntryPoint;
     }
 
     @Bean
@@ -117,6 +120,10 @@ public class SecurityConfig {
                             config.setExposedHeaders(List.of("Authorization"));
                             return config;
                         })
+                );
+        http
+                .exceptionHandling((exceptions) -> exceptions
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
                 );
         //세션 설정
         http

--- a/src/main/java/umc/snack/common/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/umc/snack/common/config/security/CustomAuthenticationEntryPoint.java
@@ -3,6 +3,7 @@ package umc.snack.common.config.security;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
@@ -15,9 +16,19 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
 
     @Override
     public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        String code = "AUTH_2113";
+        String message = "유효하지 않은 인가 코드입니다.";
+
+        if (authException instanceof AuthenticationCredentialsNotFoundException) {
+            code = "AUTH_2111";
+            message = "인가 코드가 전달되지 않았습니다.";
+        } else if (authException.getMessage() != null && authException.getMessage().contains("expired")) {
+            code = "AUTH_2112";
+            message = "만료된 인가 코드입니다.";
+        }
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json; charset=UTF-8");
-        ApiResponse<?> apiResponse = ApiResponse.onFailure("AUTH_2111", "인가 코드가 전달되지 않았습니다.", null);
+        ApiResponse<?> apiResponse = ApiResponse.onFailure(code, message, null);
         ObjectMapper objectMapper = new ObjectMapper();
         response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
     }

--- a/src/main/java/umc/snack/common/config/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/umc/snack/common/config/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,24 @@
+package umc.snack.common.config.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+import umc.snack.common.dto.ApiResponse;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json; charset=UTF-8");
+        ApiResponse<?> apiResponse = ApiResponse.onFailure("AUTH_2111", "인가 코드가 전달되지 않았습니다.", null);
+        ObjectMapper objectMapper = new ObjectMapper();
+        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
+    }
+}

--- a/src/main/java/umc/snack/controller/user/UserController.java
+++ b/src/main/java/umc/snack/controller/user/UserController.java
@@ -5,7 +5,9 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import umc.snack.common.config.security.CustomUserDetails;
 import umc.snack.common.dto.ApiResponse;
 import umc.snack.domain.user.dto.UserSignupRequestDto;
 import umc.snack.domain.user.dto.UserSignupResponseDto;
@@ -28,7 +30,7 @@ public class UserController {
 
         UserSignupResponseDto result = userService.signup(request);
         return ResponseEntity.ok(
-                ApiResponse.onSuccess("USER_2501", "회원가입이 정상적으로 처리되었습니다.", result)
+                ApiResponse.onSuccess("USER_2500", "회원가입이 정상적으로 처리되었습니다.", result)
         );
     }
 
@@ -48,9 +50,9 @@ public class UserController {
 
     @Operation(summary = "회원탈퇴", description = "내 계정(회원)을 탈퇴합니다.")
     @DeleteMapping("/me")
-    public ResponseEntity<?> withdrawUser() {
-        // TODO: 구현 예정
-        return ResponseEntity.ok("구현 예정");
+    public ResponseEntity<?> withdrawUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        userService.withdraw(userDetails.getUser());
+        return ResponseEntity.ok(ApiResponse.onSuccess("USER_2520","회원 탈퇴가 정상적으로 처리되었습니다.",null));
     }
 
     @Operation(summary = "내 정보 수정", description = "닉네임, 소개 등 내 정보를 수정합니다.")

--- a/src/main/java/umc/snack/domain/user/entity/User.java
+++ b/src/main/java/umc/snack/domain/user/entity/User.java
@@ -43,12 +43,9 @@ public class User extends BaseEntity {
     @Column(name = "delete_at")
     private java.time.LocalDateTime deleteAt;
 
-    public void setStatus(Status status) {
-        this.status = status;
-    }
-
-    public void setDeleteAt(LocalDateTime deleteAt) {
-        this.deleteAt = deleteAt;
+    public void withdraw() {
+                this.status = Status.DELETED;
+                this.deleteAt = LocalDateTime.now();
     }
 
     @Builder.Default

--- a/src/main/java/umc/snack/domain/user/entity/User.java
+++ b/src/main/java/umc/snack/domain/user/entity/User.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 import umc.snack.global.BaseEntity;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "users")
 @Getter
@@ -40,6 +42,14 @@ public class User extends BaseEntity {
 
     @Column(name = "delete_at")
     private java.time.LocalDateTime deleteAt;
+
+    public void setStatus(Status status) {
+        this.status = status;
+    }
+
+    public void setDeleteAt(LocalDateTime deleteAt) {
+        this.deleteAt = deleteAt;
+    }
 
     @Builder.Default
     @Enumerated(EnumType.STRING)

--- a/src/main/java/umc/snack/repository/auth/RefreshTokenRepository.java
+++ b/src/main/java/umc/snack/repository/auth/RefreshTokenRepository.java
@@ -12,7 +12,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Stri
     boolean existsByUserId(Long userId);
     void deleteByRefreshToken(String refreshToken);
     void deleteByUserId(Long userId);
-    void deleteAllByUserId(Long userId);
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
 
 }

--- a/src/main/java/umc/snack/repository/auth/RefreshTokenRepository.java
+++ b/src/main/java/umc/snack/repository/auth/RefreshTokenRepository.java
@@ -2,6 +2,7 @@ package umc.snack.repository.auth;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.snack.domain.auth.entity.RefreshToken;
+import umc.snack.domain.user.entity.User;
 
 import java.util.Optional;
 
@@ -11,6 +12,7 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Stri
     boolean existsByUserId(Long userId);
     void deleteByRefreshToken(String refreshToken);
     void deleteByUserId(Long userId);
+    void deleteAllByUserId(Long userId);
     Optional<RefreshToken> findByRefreshToken(String refreshToken);
 
 }

--- a/src/main/java/umc/snack/repository/memo/MemoRepository.java
+++ b/src/main/java/umc/snack/repository/memo/MemoRepository.java
@@ -7,4 +7,5 @@ import umc.snack.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 public interface MemoRepository extends JpaRepository<Memo, Long> {
     Page<Memo> findByUser(User user, Pageable pageable);
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/umc/snack/repository/memo/MemoRepository.java
+++ b/src/main/java/umc/snack/repository/memo/MemoRepository.java
@@ -7,5 +7,5 @@ import umc.snack.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 public interface MemoRepository extends JpaRepository<Memo, Long> {
     Page<Memo> findByUser(User user, Pageable pageable);
-    void deleteByUserId(Long userId);
+    void deleteAllByUser_UserId(Long userId);
 }

--- a/src/main/java/umc/snack/repository/scrap/UserScrapRepository.java
+++ b/src/main/java/umc/snack/repository/scrap/UserScrapRepository.java
@@ -18,4 +18,6 @@ public interface UserScrapRepository extends JpaRepository<UserScrap, Long> {
     Page<UserScrap> findAllByUserId(Long userId, Pageable pageable);
 
     List<UserScrap> findByUserIdAndCreatedAtAfter(Long userId, LocalDateTime createdAt);
+
+    void deleteByUserId(Long userId);
 }

--- a/src/main/java/umc/snack/service/user/UserService.java
+++ b/src/main/java/umc/snack/service/user/UserService.java
@@ -63,13 +63,17 @@ public class UserService {
 
     @Transactional
     public void withdraw(User user) {
-        if (user.getStatus() == User.Status.DELETED) {
+        User managedUser  = userRepository.findById(user.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_2622));
+
+        if (managedUser .getStatus() == User.Status.DELETED) {
             throw new CustomException(ErrorCode.USER_2621);
         }
-        user.setStatus(User.Status.DELETED);
-        user.setDeleteAt(LocalDateTime.now());
+
+        managedUser .setStatus(User.Status.DELETED);
+        managedUser .setDeleteAt(LocalDateTime.now());
         // refresh 토큰 삭제
-        refreshTokenRepository.deleteAllByUserId(user.getUserId());
+        refreshTokenRepository.deleteAllByUserId(managedUser.getUserId());
     }
 
     // 비밀번호 정규식 체크 메소드

--- a/src/main/java/umc/snack/service/user/UserService.java
+++ b/src/main/java/umc/snack/service/user/UserService.java
@@ -78,10 +78,10 @@ public class UserService {
         }
 
         managedUser.withdraw();
-        // refresh 토큰 삭제
+        // refresh 토큰, 탈퇴한 user관련 메모, 스크랩 DB에서 삭제
         refreshTokenRepository.deleteByUserId(managedUser.getUserId());
         userScrapRepository.deleteByUserId(managedUser.getUserId());
-        memoRepository.deleteByUserId(managedUser.getUserId());
+        memoRepository.deleteAllByUser_UserId(managedUser.getUserId());
 
     }
 


### PR DESCRIPTION
## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- 회원탈퇴 API 구현 
- soft delete방식 (db에서 삭제하지 않고 status 만 DELETED로 변경)

## 변경 사항
- src/main/java/umc/snack/common/config/SecurityConfig.java
- src/main/java/umc/snack/common/config/security/CustomAuthenticationEntryPoint.java -> 생성
- src/main/java/umc/snack/controller/user/UserController.java
- src/main/java/umc/snack/domain/user/entity/User.java
- src/main/java/umc/snack/repository/auth/RefreshTokenRepository.java
- src/main/java/umc/snack/service/user/UserService.java

## 테스트 방법
- Postman, Swagger 등으로 어떻게 테스트했는지

<img width="1111" height="55" alt="image" src="https://github.com/user-attachments/assets/285efd6f-d1d5-4aa3-81f6-d2b393faf94d" />


## 관련 이슈
- close #133 

## 특이사항
- 리뷰 시 반드시 봐야 하는 부분이 있다면

---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] 마일스톤 지정 완료
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료
- [ ] GitHub Actions 테스트 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 인증 예외 발생 시 사용자에게 맞춤형 오류 메시지를 제공하는 기능이 추가되었습니다.
  * 회원 탈퇴 기능이 구현되어, 사용자가 직접 계정을 탈퇴할 수 있습니다.

* **버그 수정**
  * 회원가입 성공 코드가 일관성 있게 수정되었습니다.

* **기타**
  * 사용자 상태 및 탈퇴 일시를 관리할 수 있도록 관련 기능이 개선되었습니다.
  * 회원 탈퇴 시 관련된 리프레시 토큰, 스크랩, 메모 데이터가 함께 삭제됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->