### PR TITLE
[feat] 사용자 정보 조회 API 구현

### DIFF
--- a/src/main/java/umc/snack/controller/user/UserController.java
+++ b/src/main/java/umc/snack/controller/user/UserController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import umc.snack.common.dto.ApiResponse;
+import umc.snack.domain.user.dto.UserInfoResponseDto;
 import umc.snack.domain.user.dto.UserSignupRequestDto;
 import umc.snack.domain.user.dto.UserSignupResponseDto;
 import umc.snack.domain.user.entity.User;
@@ -41,9 +42,11 @@ public class UserController {
 
     @Operation(summary = "마이페이지 정보 조회", description = "내 회원 정보를 조회합니다.")
     @GetMapping("/me")
-    public ResponseEntity<?> getMyPage() {
-        // TODO: 구현 예정
-        return ResponseEntity.ok("구현 예정");
+    public ResponseEntity<ApiResponse<UserInfoResponseDto>> getMyPage() {
+        UserInfoResponseDto result = userService.getCurrentUserInfo();
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess("USER_2530", "사용자 정보 조회에 성공했습니다", result)
+        );
     }
 
     @Operation(summary = "회원탈퇴", description = "내 계정(회원)을 탈퇴합니다.")

--- a/src/main/java/umc/snack/domain/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/umc/snack/domain/user/dto/UserInfoResponseDto.java
@@ -1,0 +1,33 @@
+package umc.snack.domain.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import umc.snack.domain.user.entity.User;
+
+@Getter
+public class UserInfoResponseDto {
+    private Long userId;
+    private String email;
+    private String nickname;
+    private String profileUrl;
+    private String introduction;
+
+    @Builder
+    public UserInfoResponseDto(Long userId, String email, String nickname, String profileUrl, String introduction) {
+        this.userId = userId;
+        this.email = email;
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
+        this.introduction = introduction;
+    }
+
+    public static UserInfoResponseDto fromEntity(User user) {
+        return UserInfoResponseDto.builder()
+                .userId(user.getUserId())
+                .email(user.getEmail())
+                .nickname(user.getNickname())
+                .profileUrl(user.getProfileUrl())
+                .introduction(user.getIntroduction())
+                .build();
+    }
+}

--- a/src/main/java/umc/snack/service/user/UserService.java
+++ b/src/main/java/umc/snack/service/user/UserService.java
@@ -2,10 +2,13 @@ package umc.snack.service.user;
 
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import umc.snack.common.config.security.CustomUserDetails;
 import umc.snack.common.exception.CustomException;
 import umc.snack.common.exception.ErrorCode;
+import umc.snack.domain.user.dto.UserInfoResponseDto;
 import umc.snack.domain.user.dto.UserSignupRequestDto;
 import umc.snack.domain.user.dto.UserSignupResponseDto;
 import umc.snack.domain.user.entity.User;
@@ -55,6 +58,15 @@ public class UserService {
         userRepository.save(user);
 
         return UserSignupResponseDto.fromEntity(user);
+    }
+
+    // 로그인 사용자 정보 조회
+    public UserInfoResponseDto getCurrentUserInfo() {
+        // SecurityContext에서 현재 로그인한 사용자 정보 가져오기
+        CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        User currentUser = userDetails.getUser();
+        
+        return UserInfoResponseDto.fromEntity(currentUser);
     }
 
     // 비밀번호 정규식 체크 메소드


### PR DESCRIPTION
## 작업 내용
- 로그인한 사용자의 정보를 조회하는 API (`GET /api/users/me`)를 구현했습니다.
- Spring Security의 `SecurityContextHolder`를 이용하여 인증된 사용자 정보를 가져와 반환합니다.

## 변경 사항
- **`UserInfoResponseDto.java` 추가**
  - 사용자 정보 조회의 응답을 위한 DTO를 새로 생성했습니다.
  - `User` 엔티티를 `UserInfoResponseDto`로 변환하는 `fromEntity` 정적 메서드를 포함합니다.

- **`UserService.java` 수정**
  - `getCurrentUserInfo()` 메서드를 추가했습니다.
  - `SecurityContextHolder`에서 현재 인증된 사용자의 `CustomUserDetails`를 가져온 후, 사용자 정보를 DTO로 변환하여 반환하는 로직을 구현했습니다.

- **`UserController.java` 수정**
  - `getMyPage()` 메서드(`GET /api/users/me`)의 실제 로직을 구현했습니다.
  - `UserService`의 `getCurrentUserInfo()`를 호출하고, 결과를 공통 응답 형식인 `ApiResponse`로 감싸 반환합니다.

## 테스트 방법
1. Postman 또는 Swagger를 실행합니다.
2. 로그인 API를 통해 JWT 토큰을 발급받습니다.
3. `GET /api/users/me` 엔드포인트로 요청을 보냅니다.
   - **Headers**: `Authorization` | `Bearer {발급받은_JWT_토큰}`
4. 아래와 같은 형식의 응답이 오는지 확인합니다. (HTTP Status: 200 OK)
   ```json
   {
     "isSuccess": true,
     "code": "USER_2530",
     "message": "사용자 정보 조회에 성공했습니다",
     "result": {
       "userId": 1,
       "email": "user@example.com",
       "nickname": "사용자닉네임",
       "profileUrl": "https://example.com/profiles/image.jpg",
       "introduction": "자기소개"
     }
   }

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 마이페이지에서 현재 로그인한 사용자의 정보를 확인할 수 있는 기능이 추가되었습니다.  
  * 사용자 정보에는 아이디, 이메일, 닉네임, 프로필 이미지, 자기소개가 포함됩니다.  
  * 사용자 정보 조회 시 성공 메시지와 함께 표준화된 응답이 반환됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->