### PR TITLE
[Feat] 사용자 정보 수정 기능 구현: 닉네임, 프로필 이미지, 소개 업데이트 API 추가

### DIFF
--- a/src/main/java/umc/snack/controller/user/UserController.java
+++ b/src/main/java/umc/snack/controller/user/UserController.java
@@ -12,6 +12,8 @@ import umc.snack.common.dto.ApiResponse;
 import umc.snack.domain.user.dto.UserInfoResponseDto;
 import umc.snack.domain.user.dto.UserSignupRequestDto;
 import umc.snack.domain.user.dto.UserSignupResponseDto;
+import umc.snack.domain.user.dto.UserUpdateRequestDto;
+import umc.snack.domain.user.dto.UserUpdateResponseDto;
 import umc.snack.domain.user.entity.User;
 import umc.snack.service.user.UserService;
 
@@ -58,10 +60,12 @@ public class UserController {
         return ResponseEntity.ok(ApiResponse.onSuccess("USER_2520","회원 탈퇴가 정상적으로 처리되었습니다.",null));
     }
 
-    @Operation(summary = "내 정보 수정", description = "닉네임, 소개 등 내 정보를 수정합니다.")
+    @Operation(summary = "내 정보 수정", description = "닉네임, 프로필 이미지, 소개 등 내 정보를 수정합니다.")
     @PatchMapping("/me")
-    public ResponseEntity<?> updateMyInfo(@RequestBody Object request) {
-        // TODO: 구현 예정
-        return ResponseEntity.ok("구현 예정");
+    public ResponseEntity<ApiResponse<UserUpdateResponseDto>> updateMyInfo(@RequestBody @Valid UserUpdateRequestDto request) {
+        UserUpdateResponseDto result = userService.updateMyInfo(request);
+        return ResponseEntity.ok(
+                ApiResponse.onSuccess("USER_2540", "사용자 정보가 성공적으로 수정되었습니다", result)
+        );
     }
 }

--- a/src/main/java/umc/snack/domain/user/dto/UserUpdateRequestDto.java
+++ b/src/main/java/umc/snack/domain/user/dto/UserUpdateRequestDto.java
@@ -1,0 +1,20 @@
+package umc.snack.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "사용자 정보 수정 요청 DTO")
+public class UserUpdateRequestDto {
+    
+    @Schema(description = "닉네임", example = "새로운닉네임")
+    private String nickname;
+    
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profiles/new_image.jpg")
+    private String profileUrl;
+    
+    @Schema(description = "소개", example = "안녕하세요, 새로운 소개입니다.")
+    private String introduction;
+}

--- a/src/main/java/umc/snack/domain/user/dto/UserUpdateResponseDto.java
+++ b/src/main/java/umc/snack/domain/user/dto/UserUpdateResponseDto.java
@@ -1,0 +1,35 @@
+package umc.snack.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+import umc.snack.domain.user.entity.User;
+
+@Getter
+@Schema(description = "사용자 정보 수정 응답 DTO")
+public class UserUpdateResponseDto {
+    
+    @Schema(description = "사용자 ID", example = "1")
+    private Long userId;
+    
+    @Schema(description = "닉네임", example = "새로운닉네임")
+    private String nickname;
+    
+    @Schema(description = "프로필 이미지 URL", example = "https://example.com/profiles/new_image.jpg")
+    private String profileUrl;
+
+    @Builder
+    public UserUpdateResponseDto(Long userId, String nickname, String profileUrl) {
+        this.userId = userId;
+        this.nickname = nickname;
+        this.profileUrl = profileUrl;
+    }
+
+    public static UserUpdateResponseDto fromEntity(User user) {
+        return UserUpdateResponseDto.builder()
+                .userId(user.getUserId())
+                .nickname(user.getNickname())
+                .profileUrl(user.getProfileUrl())
+                .build();
+    }
+}

--- a/src/main/java/umc/snack/domain/user/entity/User.java
+++ b/src/main/java/umc/snack/domain/user/entity/User.java
@@ -48,6 +48,18 @@ public class User extends BaseEntity {
                 this.deleteAt = LocalDateTime.now();
     }
 
+    public void updateUserInfo(String nickname, String profileUrl, String introduction) {
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+        if (profileUrl != null) {
+            this.profileUrl = profileUrl;
+        }
+        if (introduction != null) {
+            this.introduction = introduction;
+        }
+    }
+
     @Builder.Default
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)

--- a/src/main/java/umc/snack/service/user/UserService.java
+++ b/src/main/java/umc/snack/service/user/UserService.java
@@ -11,6 +11,8 @@ import umc.snack.common.exception.ErrorCode;
 import umc.snack.domain.user.dto.UserInfoResponseDto;
 import umc.snack.domain.user.dto.UserSignupRequestDto;
 import umc.snack.domain.user.dto.UserSignupResponseDto;
+import umc.snack.domain.user.dto.UserUpdateRequestDto;
+import umc.snack.domain.user.dto.UserUpdateResponseDto;
 import umc.snack.domain.user.entity.User;
 import umc.snack.repository.auth.RefreshTokenRepository;
 import umc.snack.repository.memo.MemoRepository;
@@ -113,6 +115,35 @@ public class UserService {
     private boolean isValidEmail(String email) {
         String regex = "^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$";
         return email != null && email.matches(regex);
+    }
+
+    @Transactional
+    public UserUpdateResponseDto updateMyInfo(UserUpdateRequestDto request) {
+        // SecurityContext에서 현재 로그인한 사용자 정보 가져오기
+        CustomUserDetails userDetails = (CustomUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        User currentUser = userDetails.getUser();
+
+        // 관리되는 엔티티 조회
+        User managedUser = userRepository.findById(currentUser.getUserId())
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_2622)); // 존재하지 않는 회원
+
+        // 닉네임 변경 시 유효성 검사
+        if (request.getNickname() != null) {
+            // 닉네임 형식 검사
+            if (!isValidNickname(request.getNickname())) {
+                throw new CustomException(ErrorCode.USER_2607);
+            }
+            // 닉네임 중복 검사 (자신의 현재 닉네임과 다른 경우에만)
+            if (!request.getNickname().equals(managedUser.getNickname()) && 
+                userRepository.existsByNickname(request.getNickname())) {
+                throw new CustomException(ErrorCode.USER_2641);
+            }
+        }
+
+        // 사용자 정보 업데이트
+        managedUser.updateUserInfo(request.getNickname(), request.getProfileUrl(), request.getIntroduction());
+
+        return UserUpdateResponseDto.fromEntity(managedUser);
     }
 }
 


### PR DESCRIPTION
## 작업 내용
- 사용자 정보 수정 API (`PATCH /api/users/me`) 구현
- 닉네임, 프로필 이미지 URL, 소개 필드 선택적 수정 기능 제공
- 닉네임 중복 검증 및 형식 검증 로직 추가

## 변경 사항
- **추가된 파일:**
  - `UserUpdateRequestDto.java` - 사용자 정보 수정 요청 DTO
  - `UserUpdateResponseDto.java` - 사용자 정보 수정 응답 DTO

- **수정된 파일:**
  - `User.java` - `updateUserInfo()` 메서드 추가 (선택적 필드 업데이트)
  - `UserService.java` - `updateMyInfo()` 메서드 구현 (닉네임 중복/형식 검증 포함)
  - `UserController.java` - `updateMyInfo()` 엔드포인트 구현

- **주요 로직:**
  - 수정할 필드만 포함하는 부분 업데이트 방식 적용
  - 닉네임 변경 시 중복 검사 (자신의 현재 닉네임과 다를 때만)
  - 트랜잭션 처리로 데이터 일관성 보장

## 테스트 방법
<img width="1582" height="972" alt="스크린샷 2025-08-05 오후 4 43 03" src="https://github.com/user-attachments/assets/ad3b617e-0daa-43fa-b80c-6a0f49f5333a" />
<img width="1582" height="972" alt="스크린샷 2025-08-05 오후 4 42 45" src="https://github.com/user-attachments/assets/240013ac-a66d-4046-b313-7f8b9efa4dbb" />


## 관련 이슈
- close #144

---

## 머지 전 필수 체크리스트
- [x] 제목 형식 지켰음 (`[기능] 사용자 정보 수정 API 구현`)
- [x] 라벨 지정 완료 (e.g. feature, enhancement)
- [x] 마일스톤 지정 완료
- [x] Assignee 지정 완료
- [x] Reviewer 지정 완료
- [x] GitHub Actions 테스트 통과 확인
- [x] API 문서(Swagger) 업데이트 확인
- [x] 단위 테스트 작성 및 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 내 정보 수정 기능이 추가되어 닉네임, 프로필 이미지, 자기소개를 변경할 수 있습니다.

* **버그 수정**
  * 기존에 정상 동작하지 않던 내 정보 수정 엔드포인트가 실제 정보 변경을 반영하도록 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->