### PR TITLE
feat(memo) : 메모 조회 구현

### DIFF
--- a/src/main/java/umc/snack/controller/memo/MemoController.java
+++ b/src/main/java/umc/snack/controller/memo/MemoController.java
@@ -74,4 +74,16 @@ public class MemoController {
                 null
         );
     }
+
+    @Operation(summary = "특정 기사에 대한 내 메모 조회", description = "로그인한 사용자가 특정 기사에 작성한 메모 조회")
+    @GetMapping("/my-memo")
+    public ApiResponse<MemoResponseDto.ContentDto> getMyMemoForArticle(
+            @PathVariable("article_id") Long article_id,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails) {
+
+        Long userId = customUserDetails.getUserId();
+        MemoResponseDto.ContentDto resultDto = memoQueryService.getMyMemoForArticle(article_id, userId);
+
+        return ApiResponse.onSuccess("MEMO_8505", "기사에 대한 메모 내용을 성공적으로 조회했습니다.", resultDto);
+    }
 }

--- a/src/main/java/umc/snack/domain/memo/dto/MemoResponseDto.java
+++ b/src/main/java/umc/snack/domain/memo/dto/MemoResponseDto.java
@@ -43,4 +43,8 @@ public class MemoResponseDto {
         private long totalElements;
     }
 
+    @Builder @Getter @NoArgsConstructor @AllArgsConstructor
+    public static class ContentDto {
+        private String content;
+    }
 }

--- a/src/main/java/umc/snack/repository/memo/MemoRepository.java
+++ b/src/main/java/umc/snack/repository/memo/MemoRepository.java
@@ -2,10 +2,16 @@ package umc.snack.repository.memo;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
+import umc.snack.domain.article.entity.Article;
 import umc.snack.domain.memo.entity.Memo;
 import umc.snack.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
+
+import java.util.Optional;
+
 public interface MemoRepository extends JpaRepository<Memo, Long> {
     Page<Memo> findByUser(User user, Pageable pageable);
     void deleteAllByUser_UserId(Long userId);
+
+    Optional<Memo> findByUserAndArticle(User user, Article article);
 }

--- a/src/main/java/umc/snack/service/memo/MemoCommandServiceImpl.java
+++ b/src/main/java/umc/snack/service/memo/MemoCommandServiceImpl.java
@@ -113,6 +113,7 @@ public class MemoCommandServiceImpl implements MemoCommandService {
         }
     }
 
+
     @Override
     @Transactional(readOnly = true)
     public MemoResponseDto.RedirectResultDto redirectToArticle(Long memoId, Long userId) {
@@ -139,6 +140,5 @@ public class MemoCommandServiceImpl implements MemoCommandService {
         return MemoResponseDto.RedirectResultDto.builder()
                 .redirectUrl(redirectUrl)
                 .build();
-
     }
 }

--- a/src/main/java/umc/snack/service/memo/MemoQueryService.java
+++ b/src/main/java/umc/snack/service/memo/MemoQueryService.java
@@ -4,4 +4,6 @@ import umc.snack.domain.memo.dto.MemoResponseDto;
 
 public interface MemoQueryService {
     MemoResponseDto.MemoListDto getMemosByUser(Long userId, int page, int size);
+
+    MemoResponseDto.ContentDto getMyMemoForArticle(Long articleId, Long userId);
 }

--- a/src/main/java/umc/snack/service/memo/MemoQueryServiceImpl.java
+++ b/src/main/java/umc/snack/service/memo/MemoQueryServiceImpl.java
@@ -10,9 +10,11 @@ import org.springframework.transaction.annotation.Transactional;
 import umc.snack.common.exception.CustomException;
 import umc.snack.common.exception.ErrorCode;
 import umc.snack.converter.memo.MemoConverter;
+import umc.snack.domain.article.entity.Article;
 import umc.snack.domain.memo.dto.MemoResponseDto;
 import umc.snack.domain.memo.entity.Memo;
 import umc.snack.domain.user.entity.User;
+import umc.snack.repository.article.ArticleRepository;
 import umc.snack.repository.memo.MemoRepository;
 import umc.snack.repository.user.UserRepository;
 
@@ -22,6 +24,7 @@ import umc.snack.repository.user.UserRepository;
 public class MemoQueryServiceImpl implements MemoQueryService {
     private final MemoRepository memoRepository;
     private final UserRepository userRepository;
+    private final ArticleRepository articleRepository;
 
     @Override
     public MemoResponseDto.MemoListDto getMemosByUser(Long userId, int page, int size) {
@@ -36,5 +39,24 @@ public class MemoQueryServiceImpl implements MemoQueryService {
             throw new CustomException(ErrorCode.REQ_3104);
 
         return MemoConverter.toMemoListDto(memoPage);
+    }
+
+    @Override
+    public MemoResponseDto.ContentDto getMyMemoForArticle(Long articleId, Long userId) {
+        // 유효한 사용자인지 확인
+        User currentUser = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_2622));
+
+        // 유효한 기사인지 확인
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMO_8605));
+
+        // 해당 사용자가 해당 기사에 작성한 메모 조회
+        Memo memo = memoRepository.findByUserAndArticle(currentUser, article)
+                .orElseThrow(() -> new CustomException(ErrorCode.MEMO_8601)); // 해당 기사에 작성된 메모를 찾을 수 없습니다.
+
+        return MemoResponseDto.ContentDto.builder()
+                .content(memo.getContent())
+                .build();
     }
 }


### PR DESCRIPTION
## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- 메모 조회 구현

## 변경 사항
- src/main/java/umc/snack/service/memo/MemoQueryServiceImpl.java

## 테스트 방법
- Swagger 
- <img width="1478" height="1111" alt="스크린샷 2025-08-06 오전 5 32 52" src="https://github.com/user-attachments/assets/a860891c-3075-45ce-9c41-69b2b6f02377" />
<img width="1478" height="1111" alt="스크린샷 2025-08-06 오전 5 32 43" src="https://github.com/user-attachments/assets/d4b1347d-8d05-438d-9248-0e9d3c3db31a" />

## 관련 이슈
- close #152 

## 특이사항
- 리뷰 시 반드시 봐야 하는 부분 X

---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료


> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자가 특정 아티클에 대해 작성한 자신의 메모를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.

* **버그 수정**
  * 해당 없음.

* **기타**
  * 내부적으로 메모 조회 기능을 위한 데이터 구조 및 서비스가 확장되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->