### PR TITLE
[fix] 프로필 이미지 처리 업데이트

### DIFF
--- a/src/main/java/umc/snack/domain/user/dto/UserInfoResponseDto.java
+++ b/src/main/java/umc/snack/domain/user/dto/UserInfoResponseDto.java
@@ -9,15 +9,15 @@ public class UserInfoResponseDto {
     private Long userId;
     private String email;
     private String nickname;
-    private String profileUrl;
+    private String profileImage;
     private String introduction;
 
     @Builder
-    public UserInfoResponseDto(Long userId, String email, String nickname, String profileUrl, String introduction) {
+    public UserInfoResponseDto(Long userId, String email, String nickname, String profileImage, String introduction) {
         this.userId = userId;
         this.email = email;
         this.nickname = nickname;
-        this.profileUrl = profileUrl;
+        this.profileImage = profileImage;
         this.introduction = introduction;
     }
 
@@ -26,7 +26,7 @@ public class UserInfoResponseDto {
                 .userId(user.getUserId())
                 .email(user.getEmail())
                 .nickname(user.getNickname())
-                .profileUrl(user.getProfileUrl())
+                .profileImage(user.getProfileImage())
                 .introduction(user.getIntroduction())
                 .build();
     }

--- a/src/main/java/umc/snack/domain/user/dto/UserUpdateRequestDto.java
+++ b/src/main/java/umc/snack/domain/user/dto/UserUpdateRequestDto.java
@@ -13,7 +13,7 @@ public class UserUpdateRequestDto {
     private String nickname;
     
     @Schema(description = "프로필 이미지 URL", example = "https://example.com/profiles/new_image.jpg")
-    private String profileUrl;
+    private String profileImage;
     
     @Schema(description = "소개", example = "안녕하세요, 새로운 소개입니다.")
     private String introduction;

--- a/src/main/java/umc/snack/domain/user/dto/UserUpdateResponseDto.java
+++ b/src/main/java/umc/snack/domain/user/dto/UserUpdateResponseDto.java
@@ -16,20 +16,20 @@ public class UserUpdateResponseDto {
     private String nickname;
     
     @Schema(description = "프로필 이미지 URL", example = "https://example.com/profiles/new_image.jpg")
-    private String profileUrl;
+    private String profileImage;
 
     @Builder
-    public UserUpdateResponseDto(Long userId, String nickname, String profileUrl) {
+    public UserUpdateResponseDto(Long userId, String nickname, String profileImage) {
         this.userId = userId;
         this.nickname = nickname;
-        this.profileUrl = profileUrl;
+        this.profileImage = profileImage;
     }
 
     public static UserUpdateResponseDto fromEntity(User user) {
         return UserUpdateResponseDto.builder()
                 .userId(user.getUserId())
                 .nickname(user.getNickname())
-                .profileUrl(user.getProfileUrl())
+                .profileImage(user.getProfileImage())
                 .build();
     }
 }

--- a/src/main/java/umc/snack/domain/user/entity/User.java
+++ b/src/main/java/umc/snack/domain/user/entity/User.java
@@ -28,9 +28,11 @@ public class User extends BaseEntity {
     @Column(unique = true, nullable = false, length = 255)
     private String nickname;
 
+    // 프로필의 링크
     @Column(name = "profile_url")
     private String profileUrl;
 
+    // 프로필 사진의 링크
     @Column(name = "profile_image")
     private String profileImage;
 
@@ -48,12 +50,12 @@ public class User extends BaseEntity {
                 this.deleteAt = LocalDateTime.now();
     }
 
-    public void updateUserInfo(String nickname, String profileUrl, String introduction) {
+    public void updateUserInfo(String nickname, String profileImage, String introduction) {
         if (nickname != null) {
             this.nickname = nickname;
         }
-        if (profileUrl != null) {
-            this.profileUrl = profileUrl;
+        if (profileImage != null) {
+            this.profileImage = profileImage;
         }
         if (introduction != null) {
             this.introduction = introduction;

--- a/src/main/java/umc/snack/service/file/S3FileService.java
+++ b/src/main/java/umc/snack/service/file/S3FileService.java
@@ -111,9 +111,9 @@ public class S3FileService {
                 .orElseThrow(() -> new CustomException(ErrorCode.USER_2622));
 
         // 프로필 이미지 URL 검증
-        if (managedUser.getProfileUrl() == null || !managedUser.getProfileUrl().equals(fileUrl)) {
+        if (managedUser.getProfileImage() == null || !managedUser.getProfileImage().equals(fileUrl)) {
             log.warn("User {} attempted to delete profile image they don't own. Requested: {}, Actual: {}", 
-                    currentUser.getUserId(), fileUrl, managedUser.getProfileUrl());
+                    currentUser.getUserId(), fileUrl, managedUser.getProfileImage());
             throw new CustomException(ErrorCode.UNAUTHORIZED_FILE_ACCESS);
         }
 

--- a/src/main/java/umc/snack/service/user/UserService.java
+++ b/src/main/java/umc/snack/service/user/UserService.java
@@ -147,7 +147,7 @@ public class UserService {
         }
 
         // 사용자 정보 업데이트
-        managedUser.updateUserInfo(request.getNickname(), request.getProfileUrl(), request.getIntroduction());
+        managedUser.updateUserInfo(request.getNickname(), request.getProfileImage(), request.getIntroduction());
 
         return UserUpdateResponseDto.fromEntity(managedUser);
     }


### PR DESCRIPTION



## 작업 내용
- 사용자 관련 클래스와 메서드에서 `profileUrl`을 `profileImage`로 변경

## 변경 사항
- 사용자 관련 클래스와 메서드에서 `profileUrl`을 `profileImage`로 변경


## 관련 이슈
- close #158 


---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] 마일스톤 지정 완료
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료
- [ ] GitHub Actions 테스트 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 사용자 프로필 이미지 관련 필드명이 기존의 profileUrl에서 profileImage로 변경되었습니다. 이로 인해 사용자 정보 조회 및 수정 응답 등에서 profileImage로 표기됩니다.  
  * 관련 입력 및 응답 값의 명칭이 일관되게 profileImage로 통일되었습니다.  
  * 내부 동작과 화면상 표기 외의 기능 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->