### PR TITLE
[feat] 관련 기사 조회 기능 구현 + 카페인 캐시

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,8 +35,6 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    implementation 'org.springframework.boot:spring-boot-starter-security'
-    testImplementation 'org.springframework.security:spring-security-test'
     runtimeOnly 'com.mysql:mysql-connector-j:8.0.33'
 
 	// swagger

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
 	// 카페인 캐시 엔진
 	implementation 'com.github.ben-manes.caffeine:caffeine'
+	// 캐시 모니터링 액츄에이터
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,11 @@ dependencies {
 	// AWS S3
 	implementation 'software.amazon.awssdk:s3:2.28.15'
 	implementation 'software.amazon.awssdk:auth:2.28.15'
+
+	// 스프링 캐시 표준 기능
+	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	// 카페인 캐시 엔진
+	implementation 'com.github.ben-manes.caffeine:caffeine'
 }
 
 tasks.named('test') {

--- a/src/main/java/umc/snack/SnackApplication.java
+++ b/src/main/java/umc/snack/SnackApplication.java
@@ -2,12 +2,14 @@ package umc.snack;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 // @EnableJpaAuditing
 @EnableScheduling
+@EnableCaching
 public class SnackApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/umc/snack/common/config/SecurityConfig.java
+++ b/src/main/java/umc/snack/common/config/SecurityConfig.java
@@ -101,7 +101,9 @@ public class SecurityConfig {
                                 "/api/share/**",
                                 "/api/articles/crawl/status",
                                 "/api/articles/*/summarize",
-                                "/api/terms"
+                                "/api/terms",
+                                //캐시 액츄에이터
+                                "actuator/**"
                         ).permitAll()
                         // 나머지는 모두 JWT 토큰 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/umc/snack/common/config/SecurityConfig.java
+++ b/src/main/java/umc/snack/common/config/SecurityConfig.java
@@ -103,7 +103,7 @@ public class SecurityConfig {
                                 "/api/articles/*/summarize",
                                 "/api/terms",
                                 //캐시 액츄에이터
-                                "actuator/**"
+                                "/actuator/**"
                         ).permitAll()
                         // 나머지는 모두 JWT 토큰 인증 필요
                         .anyRequest().authenticated()

--- a/src/main/java/umc/snack/controller/article/ArticleController.java
+++ b/src/main/java/umc/snack/controller/article/ArticleController.java
@@ -94,7 +94,7 @@ public class ArticleController {
         List<RelatedArticleDto> relatedArticles = articleService.findRelatedArticles(articleId);
         if (relatedArticles.isEmpty()) {
             return ResponseEntity.ok(
-                    ApiResponse.onSuccess("ARTICLE_9004", "해당 기사와 관련된 기사가 없습니다.", null));
+                    ApiResponse.onSuccess("ARTICLE_9004", "해당 기사와 관련된 기사가 없습니다.", List.of()));
         } else {
             return ResponseEntity.ok(
                     ApiResponse.onSuccess("ARTICLE_9003", "관련 기사 조회에 성공하였습니다.", relatedArticles)

--- a/src/main/java/umc/snack/controller/article/ArticleController.java
+++ b/src/main/java/umc/snack/controller/article/ArticleController.java
@@ -2,6 +2,7 @@ package umc.snack.controller.article;
 
 import umc.snack.domain.article.dto.ArticleDto;
 
+import umc.snack.domain.article.dto.RelatedArticleDto;
 import umc.snack.domain.article.entity.CrawledArticle;
 import umc.snack.domain.term.dto.TermResponseDto;
 import umc.snack.repository.article.CrawledArticleRepository;
@@ -89,8 +90,15 @@ public class ArticleController {
 
     @Operation(summary = "관련 기사 조회", description = "현재 보고 있는 기사와 카테고리가 같은 관련 기사를 추천합니다.")
     @GetMapping("/{articleId}/related-articles")
-    public ResponseEntity<?> getRelatedArticles(@PathVariable Long articleId) {
-        // TODO: 개발 예정
-        return ResponseEntity.ok("관련 기사 조회 API - 개발 예정");
+    public ResponseEntity<ApiResponse<List<RelatedArticleDto>>> getRelatedArticles(@PathVariable Long articleId) {
+        List<RelatedArticleDto> relatedArticles = articleService.findRelatedArticles(articleId);
+        if (relatedArticles.isEmpty()) {
+            return ResponseEntity.ok(
+                    ApiResponse.onSuccess("ARTICLE_9004", "해당 기사와 관련된 기사가 없습니다.", null));
+        } else {
+            return ResponseEntity.ok(
+                    ApiResponse.onSuccess("ARTICLE_9003", "관련 기사 조회에 성공하였습니다.", relatedArticles)
+            );
+        }
     }
 }

--- a/src/main/java/umc/snack/domain/article/dto/RelatedArticleDto.java
+++ b/src/main/java/umc/snack/domain/article/dto/RelatedArticleDto.java
@@ -1,0 +1,29 @@
+package umc.snack.domain.article.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import umc.snack.domain.article.entity.Article; // Article 엔티티 import
+
+@Getter
+public class RelatedArticleDto {
+
+    private Long articleId; // 엔티티의 articleId 타입이 Long이므로 맞춰줍니다.
+    private String title;
+    private String imageUrl; // API 명세에서는 thumbnailUrl, 엔티티에서는 imageUrl
+
+    @Builder
+    public RelatedArticleDto(Long articleId, String title, String imageUrl) {
+        this.articleId = articleId;
+        this.title = title;
+        this.imageUrl = imageUrl;
+    }
+
+    // Article 엔티티를 DTO로 변환하는 정적 메소드 (수정됨)
+    public static RelatedArticleDto fromEntity(Article article) {
+        return RelatedArticleDto.builder()
+                .articleId(article.getArticleId()) // article.getArticleId() 사용
+                .title(article.getTitle())
+                .imageUrl(article.getImageUrl()) // article.getImageUrl() 사용
+                .build();
+    }
+}

--- a/src/main/java/umc/snack/domain/article/dto/RelatedArticleDto.java
+++ b/src/main/java/umc/snack/domain/article/dto/RelatedArticleDto.java
@@ -7,9 +7,9 @@ import umc.snack.domain.article.entity.Article; // Article 엔티티 import
 @Getter
 public class RelatedArticleDto {
 
-    private Long articleId; // 엔티티의 articleId 타입이 Long이므로 맞춰줍니다.
+    private Long articleId;
     private String title;
-    private String imageUrl; // API 명세에서는 thumbnailUrl, 엔티티에서는 imageUrl
+    private String imageUrl;
 
     @Builder
     public RelatedArticleDto(Long articleId, String title, String imageUrl) {

--- a/src/main/java/umc/snack/repository/article/ArticleRepository.java
+++ b/src/main/java/umc/snack/repository/article/ArticleRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import umc.snack.domain.article.entity.Article;
+import umc.snack.domain.feed.entity.Category;
 
 import java.util.List;
 import java.util.Optional;
@@ -15,4 +16,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 //    List<Article> findBySummaryIsNull();
     Page<Article> findBySummaryIsNull(Pageable pageable);
 
+    List<Article> findByArticleCategories_CategoryAndArticleIdNot(Category category, Long articleId, Pageable pageable);
+    // articleCategory의 category 이면서(AND) articleId 는 아닌 article을 찾아다오
+    // Pageable 객체에 설정된 정렬 순서와 갯수 만큼, List<Article> 형태로!
 }
+

--- a/src/main/java/umc/snack/repository/article/ArticleRepository.java
+++ b/src/main/java/umc/snack/repository/article/ArticleRepository.java
@@ -16,7 +16,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 //    List<Article> findBySummaryIsNull();
     Page<Article> findBySummaryIsNull(Pageable pageable);
 
-    List<Article> findByArticleCategories_CategoryAndArticleIdNot(Category category, Long articleId, Pageable pageable);
+    List<Article> findDistinctByArticleCategories_CategoryAndArticleIdNot(Category category, Long articleId, Pageable pageable);
     // articleCategory의 category 이면서(AND) articleId 는 아닌 article을 찾아다오
     // Pageable 객체에 설정된 정렬 순서와 갯수 만큼, List<Article> 형태로!
 }

--- a/src/main/java/umc/snack/service/article/ArticleService.java
+++ b/src/main/java/umc/snack/service/article/ArticleService.java
@@ -107,7 +107,8 @@ public class ArticleService {
         Category targetCategory = sourceArticle.getArticleCategories().get(0).getCategory();
 
         // 4. Pageable 객체 생성
-        Pageable pageable = PageRequest.of(0, RELATED_ARTICLE_COUNT, Sort.by(Sort.Direction.DESC, "publishedAt"));
+        Pageable pageable = PageRequest.of(0, RELATED_ARTICLE_COUNT,
+                Sort.by("publishedAt").descending().and(Sort.by("articleId").descending()));
 
         // 5. 쿼리 메소드 호출
         List<Article> relatedArticles = articleRepository.findDistinctByArticleCategories_CategoryAndArticleIdNot(

--- a/src/main/java/umc/snack/service/article/ArticleService.java
+++ b/src/main/java/umc/snack/service/article/ArticleService.java
@@ -104,7 +104,7 @@ public class ArticleService {
         Pageable pageable = PageRequest.of(0, RELATED_ARTICLE_COUNT, Sort.by(Sort.Direction.DESC, "publishedAt"));
 
         // 5. 쿼리 메소드 호출
-        List<Article> relatedArticles = articleRepository.findByArticleCategories_CategoryAndArticleIdNot(
+        List<Article> relatedArticles = articleRepository.findDistinctByArticleCategories_CategoryAndArticleIdNot(
                 targetCategory,
                 articleId,
                 pageable

--- a/src/main/java/umc/snack/service/article/ArticleService.java
+++ b/src/main/java/umc/snack/service/article/ArticleService.java
@@ -88,6 +88,12 @@ public class ArticleService {
     @Cacheable(value="related-articles", key="#articleId")
     @Transactional(readOnly = true)
     public List<RelatedArticleDto> findRelatedArticles(Long articleId) {
+
+        // 0. 파라미터 검증
+        if (articleId == null) {
+            throw new CustomException(ErrorCode.REQ_3102);
+        }
+
         // 1. 기준 기사 조회
         Article sourceArticle = articleRepository.findById(articleId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ARTICLE_9105_RELATED));

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,13 @@ spring:
 #        access: 60000 # 1분
 #        refresh: 180000 # 3분
 
+  cache:
+    type: caffeine # 사용할 캐시 엔진 : 카페인
+    caffeine:
+      spec: maximumSize=100,expireAfterWrite=8h # 캐시 세부 설정
+
+
+
 # 프론트엔드 URL 설정
 frontend:
   url: ${FRONTEND_URL:http://localhost:3000}
@@ -56,3 +63,4 @@ aws:
     secret-key: ${AWS_SECRET_KEY}
     region: ${AWS_REGION:ap-northeast-2}
     bucket-name: ${AWS_S3_BUCKET}
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -28,12 +28,11 @@ spring:
     caffeine:
       spec: maximumSize=100,expireAfterWrite=8h,recordStats # 캐시 세부 설정
 
-  management:
-    endpoints:
-      web:
-        exposure:
-          include: "health,info,caches" # health, info, caches 엔드포인트를 노출
-
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info,caches
 
 
 # 프론트엔드 URL 설정

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,13 @@ spring:
   cache:
     type: caffeine # 사용할 캐시 엔진 : 카페인
     caffeine:
-      spec: maximumSize=100,expireAfterWrite=8h # 캐시 세부 설정
+      spec: maximumSize=100,expireAfterWrite=8h,recordStats # 캐시 세부 설정
+
+  management:
+    endpoints:
+      web:
+        exposure:
+          include: "health,info,caches" # health, info, caches 엔드포인트를 노출
 
 
 


### PR DESCRIPTION
## 작업 내용
- 관련 기사 조회 기능 구현

## 변경 사항
-  application.yml
- build.gradle
- ArticleController
- ArticleService
- ArticleRepository
- RelatedArticleDto
- ...

## 테스트 방법
<img width="632" height="866" alt="image" src="https://github.com/user-attachments/assets/1367b827-c2e7-4d14-bdb6-5d54e2901b0a" />

<img width="615" height="593" alt="image" src="https://github.com/user-attachments/assets/28e33c86-06b9-4618-832c-f973988e048f" />

<img width="449" height="206" alt="image" src="https://github.com/user-attachments/assets/0b014777-48ca-42fc-9481-57c8af06c147" />



## 관련 이슈
- close #173 

---

## 머지 전 필수 체크리스트
- [x] 제목 형식 지켰음 (`[기능] ~`)
- [x] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] 마일스톤 지정 완료
- [x] Assignee 지정 완료
- [x] Reviewer 지정 완료
- [ ] GitHub Actions 테스트 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신기능
  * 기사 상세 화면에서 연관 기사 조회 기능을 구현했습니다(최대 3개, 최신순). 연관 콘텐츠가 없을 때도 일관된 코드/메시지로 응답합니다.
  * 연관 기사 응답이 구조화된 형식(기사ID, 제목, 이미지 URL)으로 반환됩니다.

* Chores
  * 애플리케이션 캐시 설정을 추가하고 Caffeine 기반 캐시를 도입해 반복 조회 성능을 개선했습니다.
  * 운영(Actuator) 엔드포인트가 허용되어 캐시 상태 등을 모니터링할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->