### PR TITLE
[fix] 신고 조회 여부 api 추가

### DIFF
--- a/src/main/java/umc/snack/controller/report/ReportController.java
+++ b/src/main/java/umc/snack/controller/report/ReportController.java
@@ -6,6 +6,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -47,6 +48,31 @@ public class ReportController {
         return ResponseEntity.status(201).body(response);
     }
 
+    @Operation(summary = "퀴즈 신고 상태 조회", description = "사용자가 해당 기사 퀴즈 해설을 이미 신고했는지 여부를 반환합니다.")
+    @GetMapping("/quiz/status")
+    public ResponseEntity<ApiResponse<Object>> getQuizReportStatus(
+            @PathVariable("articleId") Long articleId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long userIdFromToken = customUserDetails.getUserId();
+        boolean reported = quizReportService.hasReported(articleId, userIdFromToken);
+
+        // 응답 구조 생성
+        final boolean isReported = reported; // 변수명 충돌 방지
+        Object result = new Object() {
+            public final boolean reported = isReported;
+            public final String status = isReported ? "REPORTED" : "NOT_REPORTED";
+            public final String actionLabel = isReported ? "신고 완료" : "신고 가능";
+        };
+
+        ApiResponse<Object> response = ApiResponse.onSuccess(
+                "200",
+                "퀴즈 신고 상태 조회 성공",
+                result
+        );
+        return ResponseEntity.ok(response);
+    }
+
     @Operation(summary = "용어 신고하기", description = "기사에 포함된 용어 설명에 대해 신고를 생성합니다. 한 사용자는 같은 기사에 대해 한 번만 신고할 수 있습니다.")
     @PostMapping("/term")
     public ResponseEntity<ApiResponse<TermReportResponseDto>> reportTerm(
@@ -64,6 +90,29 @@ public class ReportController {
         );
         return ResponseEntity.status(201).body(response);
     }
+
+    @Operation(summary = "용어 신고 상태 조회", description = "사용자가 해당 기사 용어 설명을 이미 신고했는지 여부를 반환합니다.")
+    @GetMapping("/term/status")
+    public ResponseEntity<ApiResponse<Object>> getTermReportStatus(
+            @PathVariable("articleId") Long articleId,
+            @AuthenticationPrincipal CustomUserDetails customUserDetails
+    ) {
+        Long userIdFromToken = customUserDetails.getUserId();
+        boolean reported = termReportService.hasReported(articleId, userIdFromToken);
+
+        // 응답 구조 생성
+        final boolean isReported = reported; // 변수명 충돌 방지
+        Object result = new Object() {
+            public final boolean reported = isReported;
+            public final String status = isReported ? "REPORTED" : "NOT_REPORTED";
+            public final String actionLabel = isReported ? "신고 완료" : "신고 가능";
+        };
+
+        ApiResponse<Object> response = ApiResponse.onSuccess(
+                "200",
+                "용어 신고 상태 조회 성공",
+                result
+        );
+        return ResponseEntity.ok(response);
+    }
 }
-
-

--- a/src/main/java/umc/snack/domain/report/dto/QuizReportResponseDto.java
+++ b/src/main/java/umc/snack/domain/report/dto/QuizReportResponseDto.java
@@ -11,6 +11,5 @@ import lombok.NoArgsConstructor;
 @Builder
 public class QuizReportResponseDto {
     private Long reportId;
+    private boolean reported;
 }
-
-

--- a/src/main/java/umc/snack/domain/report/dto/TermReportResponseDto.java
+++ b/src/main/java/umc/snack/domain/report/dto/TermReportResponseDto.java
@@ -11,6 +11,5 @@ import lombok.NoArgsConstructor;
 @Builder
 public class TermReportResponseDto {
     private Long reportId;
+    private boolean reported;
 }
-
-

--- a/src/main/java/umc/snack/domain/report/entity/QuizReport.java
+++ b/src/main/java/umc/snack/domain/report/entity/QuizReport.java
@@ -11,6 +11,11 @@ import umc.snack.global.BaseEntity;
         name = "quiz_reports",
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"user_id", "article_id"})
+        },
+        indexes = {
+                @Index(name = "idx_qr_user", columnList = "user_id"),
+                @Index(name = "idx_qr_article", columnList = "article_id"),
+                @Index(name = "idx_qr_user_article_reported", columnList = "user_id, article_id, reported")
         }
 )
 @Getter
@@ -39,15 +44,6 @@ public class QuizReport extends BaseEntity {
 
     public boolean isReported() {
         return reported;
-    }
-
-    public void setReported(boolean reported) {
-        this.reported = reported;
-    }
-
-    /** Allow setting via 0/1 semantics if needed */
-    public void setReportedInt(int value) {
-        this.reported = (value == 1);
     }
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/umc/snack/domain/report/entity/QuizReport.java
+++ b/src/main/java/umc/snack/domain/report/entity/QuizReport.java
@@ -37,7 +37,7 @@ public class QuizReport extends BaseEntity {
 
     @Column(name = "reported", nullable = false, columnDefinition = "TINYINT(1)")
     @Builder.Default
-    private boolean reported = false;
+    private boolean reported = true;
 
     @Column(name = "reason", length = 1000)
     private String reason;

--- a/src/main/java/umc/snack/domain/report/entity/QuizReport.java
+++ b/src/main/java/umc/snack/domain/report/entity/QuizReport.java
@@ -30,12 +30,25 @@ public class QuizReport extends BaseEntity {
     @Column(name = "article_id", nullable = false)
     private Long articleId;
 
-    @Column(name = "reported", nullable = false)
+    @Column(name = "reported", nullable = false, columnDefinition = "TINYINT(1)")
     @Builder.Default
-    private Boolean reported = false;
+    private boolean reported = false;
 
     @Column(name = "reason", length = 1000)
     private String reason;
+
+    public boolean isReported() {
+        return reported;
+    }
+
+    public void setReported(boolean reported) {
+        this.reported = reported;
+    }
+
+    /** Allow setting via 0/1 semantics if needed */
+    public void setReportedInt(int value) {
+        this.reported = (value == 1);
+    }
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", insertable = false, updatable = false)

--- a/src/main/java/umc/snack/domain/report/entity/TermReport.java
+++ b/src/main/java/umc/snack/domain/report/entity/TermReport.java
@@ -14,7 +14,8 @@ import umc.snack.global.BaseEntity;
                 columnNames = {"user_id","article_id"}),
         indexes = {
             @Index(name = "idx_tr_user", columnList = "user_id"),
-            @Index(name = "idx_tr_article", columnList = "article_id")
+            @Index(name = "idx_tr_article", columnList = "article_id"),
+            @Index(name = "idx_tr_user_article_reported", columnList = "user_id, article_id, reported")
         })
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -45,12 +46,5 @@ public class TermReport extends BaseEntity {
         return reported;
     }
 
-    public void setReported(boolean reported) {
-        this.reported = reported;
-    }
 
-    /** Allow setting via 0/1 semantics if needed */
-    public void setReportedInt(int value) {
-        this.reported = (value == 1);
-    }
 }

--- a/src/main/java/umc/snack/domain/report/entity/TermReport.java
+++ b/src/main/java/umc/snack/domain/report/entity/TermReport.java
@@ -16,8 +16,10 @@ import umc.snack.global.BaseEntity;
             @Index(name = "idx_tr_user", columnList = "user_id"),
             @Index(name = "idx_tr_article", columnList = "article_id")
         })
-@Getter @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor @Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class TermReport extends BaseEntity {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "report_id")
@@ -32,26 +34,23 @@ public class TermReport extends BaseEntity {
     private Article article;
 
     @Builder.Default
-    @Column(name="reported", nullable=false)
-    private Boolean reported = true;
-
-    // Temporary mirror to satisfy legacy column 'is_reported' if present in DB
-    @Column(name = "is_reported", nullable = false)
-    private Boolean isReportedMirror;
+    @Column(name = "reported", nullable = false, columnDefinition = "TINYINT(1)")
+    private boolean reported = true;
 
     @Column(name = "reason", columnDefinition = "TEXT")
     private String reason;
 
-    @PrePersist
-    public void syncReportedBeforeInsert() {
-        if (reported == null) {
-            reported = true;
-        }
-        isReportedMirror = reported;
+    // Explicit accessors to ensure service layer calls compile
+    public boolean isReported() {
+        return reported;
     }
 
-    @PreUpdate
-    public void syncReportedBeforeUpdate() {
-        isReportedMirror = reported;
+    public void setReported(boolean reported) {
+        this.reported = reported;
+    }
+
+    /** Allow setting via 0/1 semantics if needed */
+    public void setReportedInt(int value) {
+        this.reported = (value == 1);
     }
 }

--- a/src/main/java/umc/snack/repository/report/QuizReportRepository.java
+++ b/src/main/java/umc/snack/repository/report/QuizReportRepository.java
@@ -4,7 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import umc.snack.domain.report.entity.QuizReport;
 
 public interface QuizReportRepository extends JpaRepository<QuizReport, Long> {
+
     boolean existsByUserIdAndArticleId(Long userId, Long articleId);
+
+    boolean existsByUserIdAndArticleIdAndReportedTrue(Long userId, Long articleId);
 }
-
-

--- a/src/main/java/umc/snack/repository/report/TermReportRepository.java
+++ b/src/main/java/umc/snack/repository/report/TermReportRepository.java
@@ -2,9 +2,11 @@ package umc.snack.repository.report;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import umc.snack.domain.report.entity.TermReport;
+import java.util.Optional;
 
 public interface TermReportRepository extends JpaRepository<TermReport, Long> {
+
     boolean existsByUser_UserIdAndArticle_ArticleId(Long userId, Long articleId);
+
+    boolean existsByUser_UserIdAndArticle_ArticleIdAndReportedTrue(Long userId, Long articleId);
 }
-
-

--- a/src/main/java/umc/snack/service/report/QuizReportService.java
+++ b/src/main/java/umc/snack/service/report/QuizReportService.java
@@ -5,6 +5,7 @@ import umc.snack.domain.report.dto.QuizReportResponseDto;
 
 public interface QuizReportService {
     QuizReportResponseDto createReport(Long articleId, QuizReportRequestDto requestDto, Long userIdFromToken);
+    boolean hasReported(Long articleId, Long userIdFromToken);
 }
 
 

--- a/src/main/java/umc/snack/service/report/QuizReportServiceImpl.java
+++ b/src/main/java/umc/snack/service/report/QuizReportServiceImpl.java
@@ -59,6 +59,15 @@ public class QuizReportServiceImpl implements QuizReportService {
                 .reportId(saved.getReportId())
                 .build();
     }
+
+    @Transactional(readOnly = true)
+    @Override
+    public boolean hasReported(Long articleId, Long userIdFromToken) {
+        if (userIdFromToken == null || articleId == null) {
+            throw new CustomException(ErrorCode.REPORT_8803);
+        }
+        return quizReportRepository.existsByUserIdAndArticleIdAndReportedTrue(userIdFromToken, articleId);
+    }
 }
 
 

--- a/src/main/java/umc/snack/service/report/TermReportService.java
+++ b/src/main/java/umc/snack/service/report/TermReportService.java
@@ -5,6 +5,8 @@ import umc.snack.domain.report.dto.TermReportResponseDto;
 
 public interface TermReportService {
     TermReportResponseDto createReport(Long articleId, TermReportRequestDto requestDto, Long userIdFromToken);
+
+    boolean hasReported(Long articleId, Long userIdFromToken);
 }
 
 


### PR DESCRIPTION
## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- 어떤 기능을 구현/수정했는지 요약

## 변경 사항
- 수정/추가된 주요 파일이나 로직

## 테스트 방법
- Postman, Swagger 등으로 어떻게 테스트했는지

## 관련 이슈
- close #185 

## 특이사항
- 리뷰 시 반드시 봐야 하는 부분이 있다면

---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] 마일스톤 지정 완료
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료
- [ ] GitHub Actions 테스트 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 기사별 퀴즈/용어 신고 상태 조회가 가능합니다. 각 상태 확인 엔드포인트에서 내 신고 여부(reported), 상태(REPORTED/NOT_REPORTED), 액션 라벨(신고 완료/신고 가능)을 반환합니다.
  - 신고 관련 응답 DTO에 reported 필드가 추가되어, 클라이언트가 해당 기사에 대해 이미 신고했는지 즉시 확인할 수 있습니다.
  - 엔드포인트: GET /api/articles/{articleId}/reports/quiz/status, /term/status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->