### PR TITLE
[fix] update Google social login callback to set authorization header and redirect

### DIFF
--- a/src/main/java/umc/snack/common/config/security/CookieUtil.java
+++ b/src/main/java/umc/snack/common/config/security/CookieUtil.java
@@ -7,7 +7,7 @@ public class CookieUtil {
     public static Cookie createCookie(String key, String value) {
         Cookie cookie = new Cookie(key, value);
 //        cookie.setMaxAge(24 * 60 * 60);
-        cookie.setMaxAge(10 * 60);
+        cookie.setMaxAge(3 * 10 * 60);  // 개발 단계
         cookie.setHttpOnly(true);
 //        cookie.setSecure(true);  // 배포 환경에서만 활성화
         cookie.setPath("/");

--- a/src/main/java/umc/snack/service/auth/LogoutService.java
+++ b/src/main/java/umc/snack/service/auth/LogoutService.java
@@ -83,8 +83,8 @@ public class LogoutService {
         cookie.setPath("/");
         cookie.setHttpOnly(true);
         cookie.setMaxAge(0);
-        cookie.setSecure(true);
-        cookie.setAttribute("SameSite", "Strict");
+//        cookie.setSecure(true);
+//        cookie.setAttribute("SameSite", "Strict");
         response.addCookie(cookie);
     }
 


### PR DESCRIPTION

## 작업 내용
- /api/auth/google/callback 응답을 JSON → 302 리다이렉트로 변경
- 토큰을 헤더/HttpOnly 쿠키로 설정하도록 수정


## 변경 사항
- access token: Authorization: Bearer <token> 응답 헤더로 설정
- refresh token: HttpOnly 쿠키(refresh)로 설정
- 브라우저는 바디를 무시해도 쿠키/헤더 수신 후 "/"로 이동합니다.

## 테스트 방법
- Postman, Swagger 등으로 어떻게 테스트했는지

## 관련 이슈
- close #이슈번호

## 특이사항
- 리뷰 시 반드시 봐야 하는 부분이 있다면

---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] 마일스톤 지정 완료
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료
- [ ] GitHub Actions 테스트 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 구글 로그인 성공 시 홈으로 자동 리디렉션되며, 액세스 토큰은 응답 헤더에, 리프레시 토큰은 쿠키로 설정됩니다.
- Refactor
  - 구글 OAuth 콜백 처리 방식이 JSON 본문 반환에서 리디렉션·헤더·쿠키 설정 중심으로 변경되었습니다. 인증 코드 누락 및 오류 처리 동작은 기존과 동일합니다.
- Chores
  - 리프레시 토큰 쿠키 만료 시간이 약 30분으로 연장되었습니다.
- Bug Fix / Behavior
  - 로그아웃 시 만료 쿠키에 Secure 및 SameSite 지정이 제거되어 쿠키 속성 동작이 변경되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->