### PR TITLE
[hotfix] redirect to frontend home

### DIFF
--- a/src/main/java/umc/snack/controller/auth/AuthController.java
+++ b/src/main/java/umc/snack/controller/auth/AuthController.java
@@ -72,9 +72,9 @@ public class AuthController {
 
             // 302 리다이렉트 to 홈
             return ResponseEntity.status(302)
-                    .header(HttpHeaders.LOCATION, "/")
+                    .header(HttpHeaders.LOCATION, "https://snacknews.vercel.app/")
                     .build();
-            
+
         } catch (CustomException e) {
             // 서비스에서 발생한 커스텀 예외 처리
             ErrorCode errorCode = e.getErrorCode();


### PR DESCRIPTION
## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- 어떤 기능을 구현/수정했는지 요약

## 변경 사항
- 수정/추가된 주요 파일이나 로직

## 테스트 방법
- Postman, Swagger 등으로 어떻게 테스트했는지

## 관련 이슈
- close #이슈번호

## 특이사항
- 리뷰 시 반드시 봐야 하는 부분이 있다면

---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] 마일스톤 지정 완료
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료
- [ ] GitHub Actions 테스트 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * Google OAuth 로그인 완료 후 리디렉션 대상이 '/'에서 'https://snacknews.vercel.app/'으로 변경되었습니다. 로그인 직후 해당 도메인으로 이동합니다.
  * 기존의 인증 헤더 설정과 리프레시 쿠키 처리 흐름은 그대로 유지됩니다.
  * 오류 처리 동작도 종전과 동일합니다.
* Chores
  * 공개 API 및 메서드 시그니처 변경 없음.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->