### PR TITLE
[fix] 크로스 도메인 쿠키 지원

### DIFF
--- a/src/main/java/umc/snack/common/config/security/CookieUtil.java
+++ b/src/main/java/umc/snack/common/config/security/CookieUtil.java
@@ -1,16 +1,33 @@
 package umc.snack.common.config.security;
 
-import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseCookie;
 
 public class CookieUtil {
-    // 쿠키 생성 메서드
-    public static Cookie createCookie(String key, String value) {
-        Cookie cookie = new Cookie(key, value);
-//        cookie.setMaxAge(24 * 60 * 60);
-        cookie.setMaxAge(3 * 10 * 60);  // 개발 단계
-        cookie.setHttpOnly(true);
-//        cookie.setSecure(true);  // 배포 환경에서만 활성화
-        cookie.setPath("/");
-        return cookie;
+    // Cross-Domain 환경을 지원하는 쿠키 생성 메서드 (ResponseCookie 사용)
+    public static void createCookie(String key, String value, HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(key, value)
+                .maxAge(3 * 10 * 60)  // 개발 단계: 30분
+                .httpOnly(true)
+                .secure(true)  // HTTPS 환경에서만 전송
+                .path("/")
+                .sameSite("None")  // Cross-Domain 허용
+                .build();
+        
+        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+    }
+    
+    // 쿠키 삭제를 위한 메서드
+    public static void deleteCookie(String key, HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(key, "")
+                .maxAge(0)
+                .httpOnly(true)
+                .secure(true)
+                .path("/")
+                .sameSite("None")
+                .build();
+        
+        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }

--- a/src/main/java/umc/snack/common/config/security/jwt/LoginFilter.java
+++ b/src/main/java/umc/snack/common/config/security/jwt/LoginFilter.java
@@ -110,9 +110,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
 
         response.setContentType("application/json; charset=UTF-8");
         response.setStatus(HttpStatus.OK.value());
-        // 헤더/쿠키 유지
+        // 헤더/쿠키 설정
         response.setHeader("Authorization", "Bearer " + accessToken);
-        response.addCookie(createCookie("refresh", refreshToken));
+        createCookie("refresh", refreshToken, response);
 
         try {
             ObjectMapper mapper = new ObjectMapper();

--- a/src/main/java/umc/snack/service/article/ArticleSummarizeService.java
+++ b/src/main/java/umc/snack/service/article/ArticleSummarizeService.java
@@ -48,7 +48,7 @@ public class ArticleSummarizeService {
                         
              [규칙]
              1. 요약: 한글 기준 공백 제외 700자 이내로 간결하게.
-             2. 퀴즈: 기사 내용 기반 4지선다 객관식 2문항 작성.
+             2. 퀴즈: 요약된 기사 내용 기반 4지선다 객관식 2문항 작성.
                 - 각 문항은 반드시 다음 키를 포함: question, options(1~4 id 포함), answer, explanation.
                 - answer 형식: "{보기번호}. {보기내용}"
              3. 용어: 중·고등학생이 이해하기 어려울 만한 단어 4개 선정.

--- a/src/main/java/umc/snack/service/article/ArticleSummarizeService.java
+++ b/src/main/java/umc/snack/service/article/ArticleSummarizeService.java
@@ -51,7 +51,7 @@ public class ArticleSummarizeService {
              2. 퀴즈: 요약된 기사 내용 기반 4지선다 객관식 2문항 작성.
                 - 각 문항은 반드시 다음 키를 포함: question, options(1~4 id 포함), answer, explanation.
                 - answer 형식: "{보기번호}. {보기내용}"
-             3. 용어: 중·고등학생이 이해하기 어려울 만한 단어 4개 선정.
+             3. 용어: 요약된 기사 기반 중·고등학생이 이해하기 어려울 만한 단어 4개 선정.
                 - meaning은 품사에 맞게: 명사는 ‘…명사형 어미’, 형용사는 ‘…형용사형 어미’로 끝낼 것.
                 - meaning의 끝에 '.' 붙이지 말 것.
                 - 각 항목에 word, meaning.

--- a/src/main/java/umc/snack/service/auth/LogoutService.java
+++ b/src/main/java/umc/snack/service/auth/LogoutService.java
@@ -13,6 +13,8 @@ import umc.snack.common.exception.ErrorCode;
 import umc.snack.common.dto.ApiResponse;
 import umc.snack.repository.auth.RefreshTokenRepository;
 
+import static umc.snack.common.config.security.CookieUtil.deleteCookie;
+
 @Service
 @RequiredArgsConstructor
 public class LogoutService {
@@ -28,7 +30,7 @@ public class LogoutService {
 
         if (refreshToken == null) {
             // [AUTH_2163] 쿠키에 refresh token 없음
-            expireRefreshCookie(response);
+            deleteCookie("refresh", response);
             return buildFail(ErrorCode.AUTH_2163);
         }
 
@@ -36,7 +38,7 @@ public class LogoutService {
         var foundOpt = refreshTokenRepository.findByRefreshToken(refreshToken);
         if (foundOpt.isEmpty()) {
             // [AUTH_2132] 이미 로그아웃/없는 토큰
-            expireRefreshCookie(response);
+            deleteCookie("refresh", response);
             return buildFail(ErrorCode.AUTH_2132);
         }
 
@@ -46,13 +48,13 @@ public class LogoutService {
         } catch (ExpiredJwtException e) {
             // [AUTH_2164] 만료된 토큰
             refreshTokenRepository.deleteByRefreshToken(refreshToken);
-            expireRefreshCookie(response);
+            deleteCookie("refresh", response);
             return buildFail(ErrorCode.AUTH_2164);
         }
 
         // 4. 정상 로그아웃 (refresh token 삭제 + 쿠키 만료)
         refreshTokenRepository.deleteByRefreshToken(refreshToken);
-        expireRefreshCookie(response);
+        deleteCookie("refresh", response);
 
         // 5. 성공 응답
         return ResponseEntity.ok(
@@ -77,18 +79,7 @@ public class LogoutService {
         return null;
     }
 
-    // refresh 쿠키 만료 처리
-    private void expireRefreshCookie(HttpServletResponse response) {
-        Cookie cookie = new Cookie("refresh", null);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-        cookie.setMaxAge(0);
-//        cookie.setSecure(true);
-//        cookie.setAttribute("SameSite", "Strict");
-        response.addCookie(cookie);
-    }
-
-    // 실패 응답 빌더
+    // 실패 응답 빌더 (사용하지 않지만 호환성 유지)
     private ResponseEntity<ApiResponse<Object>> buildFail(ErrorCode errorCode) {
         return ResponseEntity
                 .status(errorCode.getStatus())

--- a/src/main/java/umc/snack/service/auth/ReissueService.java
+++ b/src/main/java/umc/snack/service/auth/ReissueService.java
@@ -95,9 +95,8 @@ public class ReissueService {
                         .build()
         );
 
-        // access 토큰은 header, refresh 토큰은 쿠키
-        response.setHeader("Authorization", "Bearer " + newAccess);
-        response.addCookie(createCookie("refresh", newRefresh));
+        // Cross-Domain 환경을 위한 쿠키 설정
+        createCookie("refresh", newRefresh, response);
 
         // 응답 Dto 만들기
         TokenReissueResponseDto dto = TokenReissueResponseDto.builder()
@@ -106,6 +105,9 @@ public class ReissueService {
                 .nickname(user.getNickname())
                 .build();
 
+        // access 토큰은 header, refresh 토큰은 Secure HttpOnly 쿠키로 설정
+        response.setHeader("Authorization", "Bearer " + newAccess);
+        
         return ResponseEntity.ok(
                 ApiResponse.onSuccess(
                         "AUTH_2060",


### PR DESCRIPTION
- enhance cookie handling for cross-domain support

## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- 어떤 기능을 구현/수정했는지 요약

## 변경 사항
- 수정/추가된 주요 파일이나 로직

## 테스트 방법
- Postman, Swagger 등으로 어떻게 테스트했는지

## 관련 이슈
- close #이슈번호

## 특이사항
- 리뷰 시 반드시 봐야 하는 부분이 있다면

---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] 마일스톤 지정 완료
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료
- [ ] GitHub Actions 테스트 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 프론트엔드 URL 설정값을 사용한 리다이렉트 경로 적용(성공/에러).
  - OAuth 성공 시 액세스 토큰은 Authorization 헤더로, 리프레시 토큰은 Secure HttpOnly 쿠키로 전달.
  - 기사 요약 기반 퀴즈/용어 생성 규칙 업데이트 및 한자 제외 제약 추가.

- Bug Fixes
  - 크로스 도메인 동작을 위한 쿠키 속성 개선: SameSite=None, Secure, HttpOnly, path="/", 30분 만료.
  - 로그아웃·만료 시 리프레시 쿠키 즉시 삭제로 세션 정리 일관성 강화.
  - 토큰 재발급 시 리프레시 쿠키 안전하게 재설정.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->