### PR TITLE
[fix] cookieUtil 클래스 만료기간 1일로 변경

### DIFF
--- a/src/main/java/umc/snack/common/config/security/CookieUtil.java
+++ b/src/main/java/umc/snack/common/config/security/CookieUtil.java
@@ -15,7 +15,7 @@ public class CookieUtil {
                 .sameSite("None")  // Cross-Domain 허용
                 .build();
         
-        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
     
     // 쿠키 삭제를 위한 메서드
@@ -28,6 +28,6 @@ public class CookieUtil {
                 .sameSite("None")
                 .build();
         
-        response.setHeader(HttpHeaders.SET_COOKIE, cookie.toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, cookie.toString());
     }
 }


### PR DESCRIPTION
## 제목 형식
- `[기능] 로그인 API 구현`
- `[버그] 로그인 에러 수정`
- `[리팩토링] 토큰 로직 개선`

---

## 작업 내용
- 어떤 기능을 구현/수정했는지 요약

## 변경 사항
- 수정/추가된 주요 파일이나 로직

## 테스트 방법
- Postman, Swagger 등으로 어떻게 테스트했는지

## 관련 이슈
- close #이슈번호

## 특이사항
- 리뷰 시 반드시 봐야 하는 부분이 있다면

---

## 머지 전 필수 체크리스트
- [ ] 제목 형식 지켰음 (`[기능] ~`)
- [ ] 라벨 지정 완료 (e.g. feature, bugfix)
- [ ] 마일스톤 지정 완료
- [ ] Assignee 지정 완료
- [ ] Reviewer 지정 완료
- [ ] GitHub Actions 테스트 통과 확인

> ⚠ **체크리스트가 모두 완료되지 않으면 merge 하지 마시오**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * 인증 쿠키의 만료 시간을 30분에서 1일로 연장했습니다. 브라우저를 닫았다가 다시 열어도 로그인 상태가 더 오래 유지되어 재로그인 빈도가 줄어듭니다.
  * HTTPOnly, Secure, SameSite 등 보안 속성과 경로 설정은 기존과 동일하게 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->